### PR TITLE
Fix/boolean config divergence

### DIFF
--- a/bench/runner.py
+++ b/bench/runner.py
@@ -106,7 +106,7 @@ def check(spec: dict, report: dict) -> list[str]:
         if want is None or k not in resolved:
             continue
         got = resolved[k]
-        if isinstance(want, bool) or got == want:
+        if got == want:
             continue
         # str() both sides: paths and numbers arrive as strings on argv.
         if str(got) == str(want):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -126,6 +126,22 @@ def test_bool_knobs_become_flag_or_no_flag():
     assert "--no-fused-adam" in build_cmd({"fused_adam": False}, Path("/tmp/r"))
 
 
+def test_boolean_divergence_true_to_false_is_fatal():
+    """A requested true flag must not be reported as successfully resolved false."""
+    bad = check({"fused_adam": True}, _report(fused_adam=False))
+    assert bad and "fused_adam" in bad[0]
+
+
+def test_boolean_divergence_false_to_true_is_fatal():
+    """A requested false flag must not be reported as successfully resolved true."""
+    bad = check({"fused_adam": False}, _report(fused_adam=True))
+    assert bad and "fused_adam" in bad[0]
+
+
+def test_boolean_agreement_is_silent():
+    assert check({"fused_adam": True}, _report(fused_adam=True)) == []
+
+
 def test_steps_divergence_without_a_scaler_is_NOT_excused():
     """The allow-list must check that its trigger actually fired.
 


### PR DESCRIPTION
## Summary

Fix benchmark configuration validation for boolean options.

## Problem

`bench.runner.check()` compares the settings requested by a benchmark with the configuration actually reported by the trainer.

Before this change, boolean settings were explicitly skipped by this condition:

`if isinstance(want, bool) or got == want:`

sO any requested boolean value was accepted w/o checking whether its value matched the trainer's resolved configuration. For example, a benchmark requesting `fused_adam=True` could pass even when the trainer reported `fused_adam=False`.

This could associate a benchmark result with the wrong configuration.

## Fix

The boolean bypass has been removed so boolean values are checked with the same equality comparison as the other resolved settings.

Matching boolean values continue to pass normally. A mismatch is now reported as a configuration divergence and causes the benchmark run to fail in strict mode.

## Tests

Added regression tests covering:

- A requested `True` value with a resolved `False` value.
- A requested `False` value with a resolved `True` value.
- Matching boolean values remaining accepted.