### PR TITLE
Fix selective Adam integration with the training loop

### DIFF
--- a/metal_gauss/mcmc.py
+++ b/metal_gauss/mcmc.py
@@ -113,6 +113,11 @@ def reset_adam_state(opt, params: dict, idx: torch.Tensor) -> None:
         for key in ("exp_avg", "exp_avg_sq"):
             if key in st:
                 st[key][idx] = 0.0
+        # SelectiveAdam keeps a step count per Gaussian so each row gets its
+        # own bias correction. Relocation/growth gives these rows a new
+        # meaning, so their history must be reset along with their moments.
+        if "steps" in st:
+            st["steps"][idx] = 0.0
 
 
 @torch.no_grad()

--- a/metal_gauss/selective_adam.py
+++ b/metal_gauss/selective_adam.py
@@ -6,6 +6,12 @@ parameter/state floats every step. Updating the visible subset by index cuts
 optimizer time and memory traffic proportionally (gsplat's selective_adam
 idea). Bias correction uses a PER-GAUSSIAN step count, matching what dense
 Adam would have done had the invisible steps simply not occurred.
+
+The trainer treats this optimizer like a regular torch optimizer: it changes
+param_groups[0]["lr"], adds an appearance-parameter group, and asks MCMC
+to reset state after relocating or growing gaussians. The implementation keeps
+that interface and uses torch Adam's state names so those operations work for
+selective Adam as well.
 """
 
 from __future__ import annotations
@@ -13,76 +19,194 @@ from __future__ import annotations
 import torch
 
 
-class SelectiveAdam:
+class SelectiveAdam(torch.optim.Optimizer):
+    """Adam with per-row updates for Gaussian parameters.
+
+    Groups marked rowwise (the default) use the visibility mask passed to
+    step() and maintain one Adam step count per Gaussian. Dense groups
+    are updated with ordinary Adam. The latter is needed for parameters such
+    as the optional per-training-image appearance correction, whose first
+    dimension is the number of images rather than the number of Gaussians.
+    """
+
     def __init__(self, groups: list[dict], eps: float = 1e-15,
                  betas: tuple[float, float] = (0.9, 0.999)):
-        self.groups = groups
-        self.eps = eps
-        self.b1, self.b2 = betas
-        self.state = {}
-        for g in groups:
-            for t in g["params"]:
-                self.state[id(t)] = {
-                    "m": torch.zeros_like(t),
-                    "v": torch.zeros_like(t),
-                    "steps": torch.zeros(t.shape[0], device=t.device),
-                }
+        defaults = {"lr": 1e-3, "eps": eps, "betas": betas}
+        super().__init__(groups, defaults)
+        # Keep the old attribute as a compatibility alias for callers that
+        # used the initial implementation before it matched torch's API.
+        self.groups = self.param_groups
+
+    def add_param_group(self, param_group: dict) -> None:
+        """Add a torch-style group, classifying appearance parameters dense."""
+        group = dict(param_group)
+        group.setdefault("rowwise", group.get("name") != "appearance")
+        super().add_param_group(group)
+
+    def _state_for(self, p: torch.Tensor, rowwise: bool) -> dict:
+        st = self.state[p]
+        if "exp_avg" not in st:
+            st["exp_avg"] = torch.zeros_like(p)
+            st["exp_avg_sq"] = torch.zeros_like(p)
+            if rowwise:
+                st["steps"] = torch.zeros(p.shape[0], device=p.device)
+            else:
+                st["step"] = 0
+        return st
+
+    @staticmethod
+    def _full_visible(visible: torch.Tensor, size: int,
+                      device: torch.device) -> torch.Tensor:
+        """Pad an active-set mask to the preallocated Gaussian capacity."""
+        if visible.numel() > size:
+            raise ValueError(
+                f"visibility mask has {visible.numel()} rows, but parameter "
+                f"has only {size}")
+        visible = visible.to(device=device)
+        if visible.numel() == size:
+            return visible
+        full = torch.zeros(size, dtype=torch.bool, device=device)
+        full[:visible.numel()] = visible
+        return full
+
+    @staticmethod
+    def _shape_for_rows(p: torch.Tensor) -> list[int]:
+        return [-1] + [1] * (p.dim() - 1)
+
+    @staticmethod
+    def _check_gradient(p: torch.Tensor) -> torch.Tensor:
+        grad = p.grad
+        if grad is None:
+            raise AssertionError("gradient checked only for non-None gradients")
+        if grad.is_sparse:
+            raise RuntimeError("SelectiveAdam does not support sparse gradients")
+        if grad.shape != p.shape:
+            raise ValueError(
+                f"gradient shape {tuple(grad.shape)} does not match parameter "
+                f"shape {tuple(p.shape)}")
+        return grad
+
+    @staticmethod
+    def _hyper(group: dict) -> tuple[float, float, float, float]:
+        b1, b2 = group["betas"]
+        return group["lr"], b1, b2, group["eps"]
 
     @torch.no_grad()
-    def step(self, visible: torch.Tensor) -> None:
-        # Index-based updates pay ~15 gather/scatter launches; when most
-        # gaussians are visible (early training, wide-angle views) that costs
-        # more than it saves. Above 50% visibility, run the same per-gaussian-
-        # step math as full-width masked ops instead -- identical result,
-        # dense-op speed. The index path wins once opacity culling and the
-        # frustum shrink visibility (late training, big budgets).
+    def step(self, visible: torch.Tensor, closure=None):
+        """Update visible Gaussian rows and any dense auxiliary groups."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if visible.ndim != 1 or visible.dtype is not torch.bool:
+            raise TypeError("visible must be a one-dimensional boolean tensor")
+
+        # The Metal renderer normally returns a mask on the same device as the
+        # Gaussian parameters. Keep the CPU-only/unit-test case convenient too.
+        for group in self.param_groups:
+            params = group["params"]
+            if params:
+                visible = visible.to(device=params[0].device)
+                break
+
         n = visible.numel()
-        nvis = int(visible.sum())
+        nvis = int(visible.sum().item())
         if nvis > n // 2:
             self._step_masked(visible)
-            return
-        idx = visible.nonzero(as_tuple=True)[0]
-        for g in self.groups:
-            lr = g["lr"]
-            for t in g["params"]:
-                if t.grad is None:
-                    continue
-                st = self.state[id(t)]
-                st["steps"][idx] += 1
-                gsel = t.grad[idx]
-                m = st["m"][idx].mul_(self.b1).add_(gsel, alpha=1 - self.b1)
-                v = st["v"][idx].mul_(self.b2).addcmul_(gsel, gsel, value=1 - self.b2)
-                st["m"][idx] = m
-                st["v"][idx] = v
-                k = st["steps"][idx]
-                bc1 = 1 - self.b1 ** k
-                bc2 = 1 - self.b2 ** k
-                shape = [-1] + [1] * (t.dim() - 1)
-                step_size = lr * (bc2.sqrt() / bc1).reshape(shape)
-                t[idx] -= step_size * m / (v.sqrt() + self.eps)
+        else:
+            self._step_indexed(visible)
+        return loss
 
-    def zero_grad(self) -> None:
-        for g in self.groups:
-            for t in g["params"]:
-                t.grad = None
+    @torch.no_grad()
+    def _step_indexed(self, visible: torch.Tensor) -> None:
+        """Use gathers/scatters when a minority of active rows is visible."""
+        idx = visible.nonzero(as_tuple=True)[0]
+        for group in self.param_groups:
+            if not group["rowwise"]:
+                self._step_dense(group)
+                continue
+            lr, b1, b2, eps = self._hyper(group)
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if p.dim() == 0 or p.shape[0] < visible.numel():
+                    raise ValueError(
+                        "rowwise SelectiveAdam parameters must have at least "
+                        "one row per visibility-mask entry")
+                grad = self._check_gradient(p)
+                if idx.numel() == 0:
+                    continue
+                st = self._state_for(p, rowwise=True)
+                steps = st["steps"][idx] + 1
+                gsel = grad[idx]
+                m = st["exp_avg"][idx] * b1 + gsel * (1 - b1)
+                v = (st["exp_avg_sq"][idx] * b2
+                     + gsel * gsel * (1 - b2))
+                st["steps"][idx] = steps
+                st["exp_avg"][idx] = m
+                st["exp_avg_sq"][idx] = v
+                k = steps
+                bc1 = 1 - b1 ** k
+                bc2 = 1 - b2 ** k
+                shape = self._shape_for_rows(p)
+                step_size = lr * (bc2.sqrt() / bc1).reshape(shape)
+                p[idx] -= step_size * m / (v.sqrt() + eps)
 
     @torch.no_grad()
     def _step_masked(self, visible: torch.Tensor) -> None:
-        for g in self.groups:
-            lr = g["lr"]
-            for t in g["params"]:
-                if t.grad is None:
+        """Use masked dense operations when most active rows are visible."""
+        for group in self.param_groups:
+            if not group["rowwise"]:
+                self._step_dense(group)
+                continue
+            lr, b1, b2, eps = self._hyper(group)
+            for p in group["params"]:
+                if p.grad is None:
                     continue
-                st = self.state[id(t)]
-                shape = [-1] + [1] * (t.dim() - 1)
-                m_mask = visible.reshape(shape).to(t.dtype)
-                st["steps"] += visible.to(st["steps"].dtype)
-                grad = t.grad * m_mask
-                # visible rows: standard Adam accumulate; invisible: unchanged
-                st["m"] = torch.where(m_mask.bool(), st["m"] * self.b1 + grad * (1 - self.b1), st["m"])
-                st["v"] = torch.where(m_mask.bool(), st["v"] * self.b2 + grad * grad * (1 - self.b2), st["v"])
+                if p.dim() == 0 or p.shape[0] < visible.numel():
+                    raise ValueError(
+                        "rowwise SelectiveAdam parameters must have at least "
+                        "one row per visibility-mask entry")
+                grad = self._check_gradient(p)
+                full_visible = self._full_visible(
+                    visible, p.shape[0], p.device)
+                shape = self._shape_for_rows(p)
+                mask = full_visible.reshape(shape)
+                st = self._state_for(p, rowwise=True)
+                st["steps"] += full_visible.to(st["steps"].dtype)
+                masked_grad = grad * mask.to(p.dtype)
+                st["exp_avg"] = torch.where(
+                    mask, st["exp_avg"] * b1 + masked_grad * (1 - b1),
+                    st["exp_avg"])
+                st["exp_avg_sq"] = torch.where(
+                    mask,
+                    st["exp_avg_sq"] * b2
+                    + masked_grad * masked_grad * (1 - b2),
+                    st["exp_avg_sq"])
                 k = st["steps"].clamp_min(1.0)
-                bc1 = 1 - self.b1 ** k
-                bc2 = 1 - self.b2 ** k
+                bc1 = 1 - b1 ** k
+                bc2 = 1 - b2 ** k
                 step_size = (lr * bc2.sqrt() / bc1).reshape(shape)
-                t -= m_mask * step_size * st["m"] / (st["v"].sqrt() + self.eps)
+                p -= (mask.to(p.dtype) * step_size * st["exp_avg"]
+                      / (st["exp_avg_sq"].sqrt() + eps))
+
+    @torch.no_grad()
+    def _step_dense(self, group: dict) -> None:
+        """Apply ordinary Adam to an auxiliary, non-Gaussian group."""
+        lr, b1, b2, eps = self._hyper(group)
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+            grad = self._check_gradient(p)
+            st = self._state_for(p, rowwise=False)
+            st["step"] += 1
+            st["exp_avg"].mul_(b1).add_(grad, alpha=1 - b1)
+            st["exp_avg_sq"].mul_(b2).addcmul_(
+                grad, grad, value=1 - b2)
+            bc1 = 1 - b1 ** st["step"]
+            bc2 = 1 - b2 ** st["step"]
+            step_size = lr * (bc2 ** 0.5) / bc1
+            p.addcdiv_(st["exp_avg"],
+                       st["exp_avg_sq"].sqrt().add(eps),
+                       value=-step_size)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -113,6 +113,73 @@ def test_selective_adam_leaves_invisible_untouched():
     assert torch.equal(t[10:], before[10:])
 
 
+def test_selective_adam_pads_active_mask_for_preallocated_gaussians():
+    """A high-visibility active set must not update inactive capacity rows."""
+    from metal_gauss.selective_adam import SelectiveAdam
+
+    t = torch.ones(12, 2, requires_grad=True)
+    before = t.detach().clone()
+    opt = SelectiveAdam([{"params": [t], "lr": 1e-2}])
+    visible = torch.ones(8, dtype=torch.bool)  # active < preallocated budget
+    t.grad = torch.ones_like(t)
+    opt.step(visible)
+
+    assert not torch.equal(t[:8], before[:8])
+    assert torch.equal(t[8:], before[8:])
+    assert torch.equal(opt.state[t]["steps"],
+                       torch.cat([torch.ones(8), torch.zeros(4)]))
+
+
+def test_selective_adam_matches_dense_for_an_auxiliary_group():
+    """Appearance parameters must use ordinary Adam, not Gaussian indexing."""
+    from metal_gauss.selective_adam import SelectiveAdam
+
+    torch.manual_seed(2)
+    gaussians = torch.randn(12, 3, requires_grad=True)
+    appearance = torch.randn(4, 3, requires_grad=True)
+    appearance_ref = appearance.detach().clone().requires_grad_(True)
+    opt = SelectiveAdam([{"params": [gaussians], "lr": 1e-2}])
+    opt.add_param_group({"params": [appearance], "lr": 3e-3,
+                         "name": "appearance"})
+    dense = torch.optim.Adam([appearance_ref], lr=3e-3, eps=1e-15)
+    visible = torch.zeros(12, dtype=torch.bool)
+    visible[:3] = True
+
+    for _ in range(3):
+        gaussians.grad = torch.randn_like(gaussians)
+        appearance.grad = torch.randn_like(appearance)
+        appearance_ref.grad = appearance.grad.clone()
+        opt.step(visible)
+        dense.step()
+
+    assert torch.allclose(appearance, appearance_ref, atol=1e-6)
+    assert "step" in opt.state[appearance]
+    assert "steps" not in opt.state[appearance]
+
+
+def test_selective_adam_exposes_standard_state_and_resettable_steps():
+    """MCMC can clear moments and per-Gaussian bias-correction history."""
+    from metal_gauss.mcmc import reset_adam_state
+    from metal_gauss.selective_adam import SelectiveAdam
+
+    t = torch.ones(8, 2, requires_grad=True)
+    opt = SelectiveAdam([{"params": [t], "lr": 1e-2}])
+    visible = torch.ones(8, dtype=torch.bool)
+    t.grad = torch.ones_like(t)
+    opt.step(visible)
+
+    state = opt.state[t]
+    assert {"exp_avg", "exp_avg_sq", "steps"} <= state.keys()
+    assert torch.all(state["steps"] == 1)
+    assert state["exp_avg"].abs().sum() > 0
+
+    reset_adam_state(opt, {"means": t}, torch.tensor([1, 6]))
+    assert torch.equal(state["steps"][[1, 6]], torch.zeros(2))
+    assert state["exp_avg"][[1, 6]].abs().sum() == 0
+    assert state["exp_avg_sq"][[1, 6]].abs().sum() == 0
+    assert torch.all(state["steps"][[0, 2, 3, 4, 5, 7]] == 1)
+
+
 # ---------------------------------------------------------------- MCMC math
 
 def test_relocation_opacity_composites_back():


### PR DESCRIPTION
## Summary

I fixed the existing `--selective-adam` option so it works with the training loop, optional appearance parameters, and MCMC relocation/growth.

## What I found

While testing the Lego scene on an Apple Silicon Mac, I tried a short run with `--selective-adam`:

```bash
caffeinate -i .venv/bin/metal-gauss-train \
  --blender data/nerf_synthetic/lego \
  --steps 1 \
  --budget 1000 \
  --max-resolution 32 \
  --num-downscales 0 \
  --eval-every 1 \
  --selective-adam
```

The run failed before the first optimizer update:

```text
AttributeError: 'SelectiveAdam' object has no attribute 'param_groups'
```

To make sure this was not caused by my local checkout, I repeated the test from a clean checkout of upstream `main` and got the same exception. I also reproduced the missing `param_groups` error with a small CPU-only example, so the failure happens before any MPS, Metal kernel, rendering, or dataset-specific behavior is involved.

The training loop uses a few standard optimizer features:

- `opt.param_groups[0]["lr"]` to update the learning rate
- `opt.add_param_group(...)` for the optional appearance parameters
- `opt.state[param]` when MCMC relocation or growth resets Adam state

The original `SelectiveAdam` implementation was a custom optimizer and did not provide those interfaces. It also stored its moments under `m` and `v`, while the MCMC code expects the usual Adam state names. In addition, the Gaussian visibility mask was applied to every parameter group, which is not valid for the optional per-image appearance parameters.

## What changed

- Make `SelectiveAdam` inherit from `torch.optim.Optimizer`.
- Use the standard `param_groups`, `state`, `add_param_group`, and `zero_grad` interfaces.
- Store Adam moments as `exp_avg` and `exp_avg_sq`.
- Keep a separate step count for each Gaussian so selective bias correction is preserved.
- Reset the per-Gaussian step counts together with the Adam moments after MCMC relocation or growth.
- Update auxiliary parameters, including appearance-correction parameters, with regular dense Adam.
- Pad active-set visibility masks to the preallocated Gaussian capacity when using the masked update path.
- Add regression tests for the optimizer interface, appearance parameters, active-set growth, and MCMC state reset.

## Checks

The full test suite passes locally:

```text
.venv/bin/python -m pytest -q
111 passed in 11.38s
```

Additional checks:

```text
.venv/bin/python bench/readme_tables.py --check
.venv/bin/python -m py_compile metal_gauss/selective_adam.py metal_gauss/mcmc.py tests/test_trainer.py
git diff --check
```

## Apple Silicon validation

After the fix, I ran the updated option with actual Metal training on the Lego scene:

- A 100-step selective Adam run completed successfully and reached 10.27 dB held-out PSNR.
- A 100-step run with selective Adam and `gain_bias` appearance correction also completed successfully.
- A 500-step selective Adam run completed successfully through Gaussian densification, reaching 19.62 dB held-out PSNR with 9,285 active splats.
- A run starting with `start_active=1000` and Gaussian growth enabled completed successfully, exercising the active-set mask handling.

These are smoke tests for correctness and successful training, not performance benchmarks.

Environment:

```text
Apple Silicon Mac
macOS 26.6.2
Python 3.12.14
PyTorch 2.13.0
MPS backend
```

This PR fixes the existing selective optimizer so it can be used by the training loop. I am not making a performance improvement claim here.