### PR TITLE
Say 188 tests, and that --steps-scaler scales the resolution schedule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ not mean the kernels are fine** — run the full suite locally.
 ```bash
 uv venv --python 3.12 .venv
 uv pip install --python .venv/bin/python -e ".[bench,train]" pytest lpips scikit-image imageio tqdm torchvision
-.venv/bin/python -m pytest -q          # 166 tests, needs an Apple GPU
+.venv/bin/python -m pytest -q          # 188 tests, needs an Apple GPU
 ```
 
 ## Performance claims need a warm machine and an idle one

--- a/metal_gauss/train.py
+++ b/metal_gauss/train.py
@@ -670,7 +670,10 @@ def main():
                          "--resolution-schedule. 0 disables (full res throughout).")
     ap.add_argument("--resolution-schedule", type=int, default=None,
                     help="steps between resolution doublings. Default steps//3, "
-                         "so full resolution is reached two thirds through.")
+                         "so full resolution is reached two thirds through. "
+                         "--steps-scaler scales this too, explicit value "
+                         "included, so a scaled run keeps the same curriculum "
+                         "in proportion.")
     ap.add_argument("--seed", type=int, default=0,
                     help="seeds torch RNG. Use the SAME seed on both arms of an "
                          "A/B so they share draws and only the tested variable "


### PR DESCRIPTION
Two lines, both loose ends from #4.

**`CONTRIBUTING.md` said 166 tests.** It is 188. That file is the one thing a contributor is told to trust before they have run anything, so a stale number in it is worse than no number.

**`--resolution-schedule` did not mention the scaler.** Since #4 an explicitly supplied value is scaled too, which is the surprising half — `--resolution-schedule 5000 --steps-scaler 0.1` gives 500, not 5000. That matches how `--relocate-every` and `--eval-every` have always behaved, but it was not written down.

188 tests pass.