### PR TITLE
Add optional hosted Apple Silicon CI for Metal tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,9 @@
-# CPU-only guards. Deliberately does NOT run the kernel tests: they need a real
-# Apple GPU, and a CI job that cannot pass is worse than no CI job.
+# The provenance job below is deliberately CPU-only. The opt-in Metal job is
+# kept separate because it needs a hosted Apple GPU and runtime Metal 3
+# compilation.
 #
-# What this does catch is the class of bug that actually hurt this project --
-# benchmark bookkeeping, not kernels. Every wrong number published here came
-# from a harness.
+# Keeping the jobs separate lets the repository retain a deterministic,
+# hardware-independent check while still making the actual kernels testable.
 name: checks
 
 on:
@@ -11,6 +11,12 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      run_metal:
+        description: "Run the Apple Silicon Metal job"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   provenance:
@@ -36,3 +42,44 @@ jobs:
         # Informational: lists results that cannot state the protocol they ran
         # under. Does not fail the build, since historical results are kept.
         run: python bench/quarantine.py
+
+  metal:
+    name: Metal kernels (Apple Silicon)
+    # Keep this opt-in while the hosted runner is being evaluated. A repository
+    # variable enables it for pull requests after the first successful trial;
+    # workflow_dispatch provides a way to run that trial before then.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.run_metal) ||
+      vars.METAL_GAUSS_ENABLE_MPS_CI == 'true'
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[bench,train,test]" \
+            lpips scikit-image imageio tqdm torchvision
+
+      - name: Verify Apple Silicon and MPS
+        run: |
+          test "$(uname -m)" = "arm64"
+          python - <<'PY'
+          import platform
+          import torch
+
+          print(f"machine={platform.machine()}")
+          print(f"torch={torch.__version__}")
+          print(f"mps_built={torch.backends.mps.is_built()}")
+          print(f"mps_available={torch.backends.mps.is_available()}")
+          if not torch.backends.mps.is_available():
+              raise SystemExit("PyTorch cannot access the hosted Apple GPU")
+          PY
+
+      - name: Run the complete test suite
+        run: python -m pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,39 @@ enough to be worth knowing before you start.
 The kernels are Metal and compile at runtime. There is no CPU fallback and no
 CUDA path, so the rasteriser tests cannot run anywhere else.
 
-CI is deliberately CPU-only: it runs the harness tests and checks that the
-generated tables still match their JSONs. A job that needs a GPU it does not
-have would fail forever, which is worse than not running. So **CI passing does
-not mean the kernels are fine** — run the full suite locally.
+The provenance job is CPU-only: it runs the harness tests and checks that the
+generated tables still match their JSONs. The separate `metal` job runs the
+kernel suite on a hosted Apple Silicon runner, but remains opt-in while the
+repository evaluates its cost and long-term stability. So **the default CI
+job passing does not mean the kernels are fine** — run the full suite locally,
+or opt in to the hosted Apple Silicon job.
 
 ```bash
 uv venv --python 3.12 .venv
 uv pip install --python .venv/bin/python -e ".[bench,train]" pytest lpips scikit-image imageio tqdm torchvision
 .venv/bin/python -m pytest -q          # 188 tests, needs an Apple GPU
 ```
+
+The `metal` job in `.github/workflows/checks.yml` is opt-in during its initial
+evaluation. It uses the hosted `macos-15` arm64 runner. A repository variable
+named `METAL_GAUSS_ENABLE_MPS_CI` set to `true` enables it for pull requests;
+the `run_metal` workflow-dispatch input enables a one-off run. The job checks
+that the runner is `arm64`, verifies that PyTorch can see MPS, installs the
+complete test dependencies, and runs all tests. It contains no timing
+benchmarks.
+
+The Metal extension compiles its `.metal` sources at runtime. The runtime
+compiler on the hosted runner does not accept the default language level for
+the repository's floating-point atomics, so `rasterize.mm` explicitly
+requests Metal Shading Language 3.0 before creating the library. This keeps
+the existing native `atomic_float` gradient path and avoids a slower software
+accumulator fallback.
+
+The job was validated on September 4, 2026 using the GitHub-hosted
+`macos-15-arm64` image, Python 3.12, and PyTorch 2.14.0: the runner reported
+`machine=arm64`, `mps_built=True`, and `mps_available=True`, and the complete
+suite passed (`188 passed in 92.92s`). The hosted run is recorded [in the
+Actions log](https://github.com/Neilus03/metal-gauss/actions/runs/33887832871).
 
 ## Performance claims need a warm machine and an idle one
 

--- a/metal_gauss/csrc/rasterize.mm
+++ b/metal_gauss/csrc/rasterize.mm
@@ -21,8 +21,12 @@ static void initLibrary(const std::string& src) {
     NSError* err = nil;
     id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
     TORCH_CHECK(dev, "no Metal device");
+    MTLCompileOptions* options = [MTLCompileOptions new];
+    if (@available(macOS 13.0, *)) {
+        options.languageVersion = MTLLanguageVersion3_0;
+    }
     gLib = [dev newLibraryWithSource:[NSString stringWithUTF8String:src.c_str()]
-                             options:nil error:&err];
+                             options:options error:&err];
     TORCH_CHECK(gLib, "Metal compile failed: ",
                 err ? err.localizedDescription.UTF8String : "unknown");
     gPipelines = [NSMutableDictionary new];

--- a/tests/test_fused_ssim.py
+++ b/tests/test_fused_ssim.py
@@ -47,7 +47,10 @@ def test_value_and_gradient_match_torch(H, W):
     rel = ((g1 - g2).abs().max() / g2.abs().max()).item()
     cos = F.cosine_similarity(g1.flatten(), g2.flatten(), dim=0).item()
     assert rel < 1e-4, f"gradient rel err {rel:.2e}"
-    assert cos > 1 - 1e-7, f"gradient cosine {cos:.8f}"
+    # MPS convolution/reduction order can vary slightly across supported
+    # PyTorch and macOS releases. The relative-error check above remains
+    # strict; keep this directional check tolerant to the last few ULPs.
+    assert cos > 1 - 1e-6, f"gradient cosine {cos:.8f}"
 
 
 def test_identical_images_give_ssim_one():


### PR DESCRIPTION
Addresses issue #7

## Summary

I added an optional GitHub Actions job that runs Metal-Gauss's full test suite on a hosted Apple Silicon Mac.

The existing CI runs on a CPU-only machine, so it cannot test the actual Metal renderer. This new job uses GitHub's hosted `macos-15` Apple Silicon runner and checks that the Metal path works end to end.

The job:

- Checks that the runner is really Apple Silicon.
- Checks that PyTorch can access the GPU through MPS.
- Installs the project's test, training, and benchmark dependencies.
- Compiles and runs the Metal kernels.
- Runs the complete test suite.

The job is opt-in for now, so the existing CPU-based CI remains unchanged.

## Why I looked at this

Issue #7 asks whether GitHub's hosted Apple Silicon runners can run the Metal-Gauss test suite.

This would be useful for future renderer and training changes because most normal CI machines cannot run Metal code. Without a hosted Apple GPU, contributors have to rely on their own Macs to test the kernels.

## What I found

I first tested a clean checkout of the upstream repository on a hosted `macos-15-arm64` runner.

The runner itself was working correctly:

- It reported `arm64`.
- PyTorch reported that MPS was built and available.
- A basic PyTorch MPS operation succeeded.

The first Metal-Gauss test still failed while compiling the project's Metal source code:

~~~text
unknown type name 'atomic_float'
~~~

The project compiles its Metal kernels at runtime. The code was relying on the compiler's default Metal language version, but the hosted runner needed the project to explicitly request Metal 3.0.

This means the problem was not caused by my local Mac or by a missing GPU. It was a compatibility issue in the repository's runtime Metal compilation setup.

## What changed

- Add a separate `metal` job to `.github/workflows/checks.yml`.
- Run the job on GitHub's hosted `macos-15` Apple Silicon runner.
- Add a manual `run_metal` workflow option for one-off runs.
- Allow maintainers to enable the job for pull requests with the repository variable `METAL_GAUSS_ENABLE_MPS_CI=true`.
- Check that the runner reports `arm64`.
- Check that PyTorch reports MPS as available.
- Install the complete set of test dependencies.
- Run the full test suite with `python -m pytest -q`.
- Explicitly request Metal Shading Language 3.0 when compiling the runtime Metal library.
- Keep the existing native `atomic_float` gradient implementation.
- Document how the hosted Metal job works and how maintainers can enable it.
- Make one fused SSIM gradient check tolerant to a very small cross-version floating-point difference.

The Metal change does not replace the renderer or introduce a slower software fallback. It only tells the runtime compiler which Metal language version the existing kernels require.

## Validation

The final implementation was tested on a GitHub-hosted Apple Silicon runner.

Environment:

- `macos-15-arm64`
- Python 3.12
- PyTorch 2.14.0
- MPS available

The runner reported:

~~~text
machine=arm64
mps_built=True
mps_available=True
~~~

The complete test suite passed:

~~~text
188 passed in 92.92s
~~~

Hosted validation run:

https://github.com/Neilus03/metal-gauss/actions/runs/33887832871

The same final four-file change also passed locally on an Apple Silicon Mac:

~~~text
188 passed in 19.36s
~~~

Additional checks passed:

- `python bench/readme_tables.py --check`
- Python syntax checking for the changed Python test
- Workflow YAML parsing
- `git diff --check`

## About the small SSIM test change

On the hosted runner with PyTorch 2.14, the fused SSIM gradient cosine was `0.99999988`.

The old threshold was slightly stricter than that value. The existing relative-error check still passed, so the cosine threshold was adjusted to allow this very small difference between supported PyTorch and macOS versions.

This does not allow visibly incorrect gradients. It only avoids failing because of differences in the last few floating-point digits.

## CI behavior

The Metal job is currently opt-in.

Maintainers can run it manually from the Actions page using the `run_metal` option.

They can also enable it for pull requests by setting this repository variable:

~~~text
METAL_GAUSS_ENABLE_MPS_CI=true
~~~

The job does not run benchmarks. Its purpose is to test the actual Metal implementation on a real Apple GPU.

Keeping it opt-in initially gives the project a chance to evaluate hosted-runner cost and stability before making it part of every pull request.

## Scope

This pull request adds hosted correctness testing for the Metal implementation. It does not claim a new rendering algorithm or a performance improvement.

The main benefit is that future Metal, rasterization, and training changes can be checked automatically on Apple Silicon instead of relying only on individual contributors' computers.