### PR TITLE
Fix Metal compile-options lifetime and cap hosted CI cost

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,12 @@ on:
         type: boolean
         default: false
 
+# Hosted macOS minutes are the scarce resource here: never leave a superseded
+# run of the same ref burning a Mac.
+concurrency:
+  group: checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   provenance:
     runs-on: ubuntu-latest
@@ -59,6 +65,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install test dependencies
         run: |

--- a/metal_gauss/csrc/rasterize.mm
+++ b/metal_gauss/csrc/rasterize.mm
@@ -21,12 +21,20 @@ static void initLibrary(const std::string& src) {
     NSError* err = nil;
     id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
     TORCH_CHECK(dev, "no Metal device");
+    // Floor, not a ceiling: the gradient kernels need MSL 3.0 for native
+    // atomic_float. Some runtime compilers (the hosted macos-15 CI image
+    // among them) default below that and reject atomic_float outright.
+    // Raise this if a kernel ever needs a later language feature.
     MTLCompileOptions* options = [MTLCompileOptions new];
     if (@available(macOS 13.0, *)) {
         options.languageVersion = MTLLanguageVersion3_0;
     }
-    gLib = [dev newLibraryWithSource:[NSString stringWithUTF8String:src.c_str()]
-                             options:options error:&err];
+    // newLibraryWithSource returns +0. gLib outlives this scope, so it needs an
+    // explicit retain under MRC; today it only survives because nothing on this
+    // call path installs an autorelease pool.
+    gLib = [[dev newLibraryWithSource:[NSString stringWithUTF8String:src.c_str()]
+                              options:options error:&err] retain];
+    [options release];  // no ARC here: see extra_cflags in metal_backend.py
     TORCH_CHECK(gLib, "Metal compile failed: ",
                 err ? err.localizedDescription.UTF8String : "unknown");
     gPipelines = [NSMutableDictionary new];


### PR DESCRIPTION
Follow-ups to #12, which is already on `main` as fa938ad.

## Objective-C memory management

`metal_gauss/csrc/rasterize.mm` is compiled without `-fobjc-arc` (`extra_cflags=["-std=c++20", "-ObjC++"]` in `metal_backend.py`), so ownership is manual:

- The `MTLCompileOptions` object added in #12 was created with `new` (+1) and never released. It is now released after `newLibraryWithSource`.
- Pre-existing, not from #12: `newLibraryWithSource` returns +0, and `gLib` is a global that outlives the scope, so it now takes an explicit `retain`. It survived until now only because nothing on this call path installs an autorelease pool.

## MSL 3.0 pin

Documented in code as a floor rather than a ceiling — the gradient kernels need it for native `atomic_float`, and the hosted `macos-15` image defaults below it. A later kernel needing a newer language feature should raise this, not delete it.

## CI

- Workflow-level `concurrency` group with `cancel-in-progress` on pull requests, so a superseded push does not leave a hosted Mac burning minutes.
- `cache: pip` on the `metal` job's `setup-python`; the torch download dominates its setup time.

## Validation

M5 MacBook Air, macOS 26.6.2, Python 3.12, PyTorch 2.14.0:

~~~text
188 passed in 32.74s
~~~

The extension was recompiled from the edited source (`rasterize.o` mtime postdates the edit). Also clean: `bench/readme_tables.py --check`, `git diff --check`, workflow YAML parse.

Note that the `metal` job stays skipped until `METAL_GAUSS_ENABLE_MPS_CI` is set to `true` on this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgF2wYZQatvZN39eSJN5BY