### PR TITLE
Decode Blender views lazily and in parallel: 8.7 s startup -> 3.0 s

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ seed cloud per scene, one evaluator on the official 200-view test split, strictl
 <!-- BEGIN:budget -->
 | you have | metal-gauss | msplat | Brush | spirula |
 |---|---:|---:|---:|---:|
-| 30 s | **21.5** | 19.9 | 12.8 | 13.8 |
-| 1 min | **24.2** | 20.8 | 14.4 | 15.1 |
+| 30 s | **21.6** | 19.9 | 12.8 | 13.8 |
+| 1 min | **24.7** | 20.8 | 14.4 | 15.1 |
 | 3 min | **29.8** | 22.1 | 18.4 | 17.4 |
-| 6 min | **31.4** | 22.3 | 23.4 | 19.6 |
+| 6 min | **31.3** | 22.3 | 23.4 | 19.6 |
 | 15 min | **31.9** | 22.4 | 26.9 | 22.1 |
 | 30 min | **31.9** | 22.4 | 26.9 | 28.5 |
 
@@ -146,8 +146,11 @@ surface. That is why the default sweep is small.
 
 - msplat is **1.3–1.8× faster per step**. Our fixed startup at that end was ~8.4 s and is now
   **~3 s**: 6.1 s of it was decoding PNGs, and 4.1 s of that decoded the 200 held-out views a run
-  without evaluation never reads. The budget rows above were measured before that and the
-  sub-0.3 min end has not been re-run.
+  without evaluation never reads. The metal-gauss rows above were re-measured after that change;
+  the competitor rows were not, and predate it.
+- That re-measurement moves the **1 min** budget by +0.5 dB and nothing else. The saving is ~4 s,
+  which is visible at the 500-iteration rung (median −4.4 s over 8 scenes) and invisible past
+  ~2 000, where run-to-run spread on the same machine is ±40 s.
 - 7 k numbers are **not comparable to published 30 k numbers** — 5.1 dB apart.
 - `--antialias` is off by default; worth **+6.68 dB at 200 px** render resolution.
 - Run-to-run noise floors: ours **0.19 dB**, Brush **0.74**, spirula **0.15–1.27**, msplat **3.35**

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ surface. That is why the default sweep is small.
 
 ## ⚠️ Caveats
 
-- msplat is **1.3–1.8× faster per step** and owns every budget under ~0.3 min. Our floor there is
-  ~8.4 s of fixed startup.
+- msplat is **1.3–1.8× faster per step**. Our fixed startup at that end was ~8.4 s and is now
+  **~3 s**: 6.1 s of it was decoding PNGs, and 4.1 s of that decoded the 200 held-out views a run
+  without evaluation never reads. The budget rows above were measured before that and the
+  sub-0.3 min end has not been re-run.
 - 7 k numbers are **not comparable to published 30 k numbers** — 5.1 dB apart.
 - `--antialias` is off by default; worth **+6.68 dB at 200 px** render resolution.
 - Run-to-run noise floors: ours **0.19 dB**, Brush **0.74**, spirula **0.15–1.27**, msplat **3.35**

--- a/README.md
+++ b/README.md
@@ -148,9 +148,15 @@ surface. That is why the default sweep is small.
   **~3 s**: 6.1 s of it was decoding PNGs, and 4.1 s of that decoded the 200 held-out views a run
   without evaluation never reads. The metal-gauss rows above were re-measured after that change;
   the competitor rows were not, and predate it.
-- That re-measurement moves the **1 min** budget by +0.5 dB and nothing else. The saving is ~4 s,
-  which is visible at the 500-iteration rung (median −4.4 s over 8 scenes) and invisible past
-  ~2 000, where run-to-run spread on the same machine is ±40 s.
+- That re-measurement moves the **1 min** budget by +0.5 dB and nothing else — and **do not lean on
+  that +0.5 dB**. It comes from three scenes whose 2 000-iteration rung cleared 60 s by 0.5, 0.9 and
+  2.2 s; re-measured later the same day against a machine also driving a desktop, none of the eight
+  cleared it. The rung boundary, not the loader, decides that row. What is solid is the saving
+  itself: ~4 s, visible at the 500 rung (median −4.4 s over 8 scenes, every scene negative) and
+  invisible past ~2 000, where run-to-run spread is ±40 s.
+- Wall-clock rows need a machine that is not also drawing a screen. The same 2 000-iteration rung
+  measured 57–68 s on an idle machine and 74–96 s while a browser was open. `require_gpu_exclusive()`
+  catches a second trainer, not a compositor.
 - 7 k numbers are **not comparable to published 30 k numbers** — 5.1 dB apart.
 - `--antialias` is off by default; worth **+6.68 dB at 200 px** render resolution.
 - Run-to-run noise floors: ours **0.19 dB**, Brush **0.74**, spirula **0.15–1.27**, msplat **3.35**

--- a/bench/results/margin_forest.svg
+++ b/bench/results/margin_forest.svg
@@ -16,73 +16,73 @@
 <text class="ti" x="14" y="22" font-size="13" font-weight="700">metal-gauss minus competitor, paired per scene (n=8)</text>
 <line class="gr" x1="220.7" y1="46" x2="220.7" y2="310"/>
 <text class="tx" x="220.7" y="326" font-size="10.5" text-anchor="middle">+0</text>
-<line class="gr" x1="291.0" y1="46" x2="291.0" y2="310"/>
-<text class="tx" x="291.0" y="326" font-size="10.5" text-anchor="middle">+2</text>
-<line class="gr" x1="361.3" y1="46" x2="361.3" y2="310"/>
-<text class="tx" x="361.3" y="326" font-size="10.5" text-anchor="middle">+4</text>
-<line class="gr" x1="431.5" y1="46" x2="431.5" y2="310"/>
-<text class="tx" x="431.5" y="326" font-size="10.5" text-anchor="middle">+6</text>
-<line class="gr" x1="501.8" y1="46" x2="501.8" y2="310"/>
-<text class="tx" x="501.8" y="326" font-size="10.5" text-anchor="middle">+8</text>
-<line class="gr" x1="572.1" y1="46" x2="572.1" y2="310"/>
-<text class="tx" x="572.1" y="326" font-size="10.5" text-anchor="middle">+10</text>
-<line class="gr" x1="642.3" y1="46" x2="642.3" y2="310"/>
-<text class="tx" x="642.3" y="326" font-size="10.5" text-anchor="middle">+12</text>
+<line class="gr" x1="291.1" y1="46" x2="291.1" y2="310"/>
+<text class="tx" x="291.1" y="326" font-size="10.5" text-anchor="middle">+2</text>
+<line class="gr" x1="361.4" y1="46" x2="361.4" y2="310"/>
+<text class="tx" x="361.4" y="326" font-size="10.5" text-anchor="middle">+4</text>
+<line class="gr" x1="431.7" y1="46" x2="431.7" y2="310"/>
+<text class="tx" x="431.7" y="326" font-size="10.5" text-anchor="middle">+6</text>
+<line class="gr" x1="502.0" y1="46" x2="502.0" y2="310"/>
+<text class="tx" x="502.0" y="326" font-size="10.5" text-anchor="middle">+8</text>
+<line class="gr" x1="572.3" y1="46" x2="572.3" y2="310"/>
+<text class="tx" x="572.3" y="326" font-size="10.5" text-anchor="middle">+10</text>
+<line class="gr" x1="642.7" y1="46" x2="642.7" y2="310"/>
+<text class="tx" x="642.7" y="326" font-size="10.5" text-anchor="middle">+12</text>
 <line class="zero" x1="220.7" y1="42" x2="220.7" y2="310" stroke-width="1.5" stroke-dasharray="4 3"/>
 <text class="tx" x="220.7" y="38" font-size="10.5" text-anchor="middle">no difference</text>
 <text class="tx" x="440" y="342" font-size="11.5" text-anchor="middle">PSNR advantage (dB), 95% CI</text>
 <text class="ti" x="156" y="70.1" font-size="11.5" text-anchor="end">spirula-studio @ 500</text>
-<line class="c0" x1="440.2" y1="66.1" x2="545.1" y2="66.1" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c0" x1="440.2" y1="62.1" x2="440.2" y2="70.1" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c0" x1="545.1" y1="62.1" x2="545.1" y2="70.1" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c0" cx="492.7" cy="66.1" r="4.5"/>
-<text class="tx" x="720" y="70.1" font-size="10.5">+7.74  (8/8)</text>
+<line class="c0" x1="441.8" y1="66.1" x2="546.6" y2="66.1" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c0" x1="441.8" y1="62.1" x2="441.8" y2="70.1" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c0" x1="546.6" y1="62.1" x2="546.6" y2="70.1" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c0" cx="494.2" cy="66.1" r="4.5"/>
+<text class="tx" x="720" y="70.1" font-size="10.5">+7.78  (8/8)</text>
 <text class="ti" x="156" y="98.3" font-size="11.5" text-anchor="end">spirula-studio @ 7k</text>
-<line class="c0" x1="411.6" y1="94.3" x2="619.0" y2="94.3" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c0" x1="411.6" y1="90.3" x2="411.6" y2="98.3" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c0" x1="619.0" y1="90.3" x2="619.0" y2="98.3" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c0" cx="515.3" cy="94.3" r="4.5"/>
-<text class="tx" x="720" y="98.3" font-size="10.5">+8.39  (8/8)</text>
+<line class="c0" x1="413.2" y1="94.3" x2="621.3" y2="94.3" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c0" x1="413.2" y1="90.3" x2="413.2" y2="98.3" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c0" x1="621.3" y1="90.3" x2="621.3" y2="98.3" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c0" cx="517.3" cy="94.3" r="4.5"/>
+<text class="tx" x="720" y="98.3" font-size="10.5">+8.43  (8/8)</text>
 <text class="ti" x="156" y="126.6" font-size="11.5" text-anchor="end">spirula-studio @ 15k</text>
-<line class="c0" x1="216.1" y1="122.6" x2="411.5" y2="122.6" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c0" x1="216.1" y1="122.6" x2="411.8" y2="122.6" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
 <line class="c0" x1="216.1" y1="118.6" x2="216.1" y2="126.6" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c0" x1="411.5" y1="118.6" x2="411.5" y2="126.6" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c0" cx="313.8" cy="122.6" r="4.5"/>
+<line class="c0" x1="411.8" y1="118.6" x2="411.8" y2="126.6" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c0" cx="314.0" cy="122.6" r="4.5"/>
 <text class="warn" x="720" y="126.6" font-size="10.5">+2.65  (7/8)  crosses 0</text>
 <text class="ti" x="156" y="154.8" font-size="11.5" text-anchor="end">Brush @ 500</text>
-<line class="c1" x1="435.0" y1="150.8" x2="615.4" y2="150.8" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c1" x1="435.0" y1="146.8" x2="435.0" y2="154.8" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c1" x1="615.4" y1="146.8" x2="615.4" y2="154.8" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c1" cx="525.2" cy="150.8" r="4.5"/>
-<text class="tx" x="720" y="154.8" font-size="10.5">+8.67  (8/8)</text>
+<line class="c1" x1="435.9" y1="150.8" x2="617.7" y2="150.8" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c1" x1="435.9" y1="146.8" x2="435.9" y2="154.8" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c1" x1="617.7" y1="146.8" x2="617.7" y2="154.8" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c1" cx="526.8" cy="150.8" r="4.5"/>
+<text class="tx" x="720" y="154.8" font-size="10.5">+8.70  (8/8)</text>
 <text class="ti" x="156" y="183.0" font-size="11.5" text-anchor="end">Brush @ 7k</text>
-<line class="c1" x1="368.2" y1="179.0" x2="539.5" y2="179.0" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c1" x1="368.2" y1="175.0" x2="368.2" y2="183.0" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c1" x1="539.5" y1="175.0" x2="539.5" y2="183.0" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c1" cx="453.9" cy="179.0" r="4.5"/>
-<text class="tx" x="720" y="183.0" font-size="10.5">+6.64  (8/8)</text>
+<line class="c1" x1="370.4" y1="179.0" x2="541.1" y2="179.0" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c1" x1="370.4" y1="175.0" x2="370.4" y2="183.0" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c1" x1="541.1" y1="175.0" x2="541.1" y2="183.0" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c1" cx="455.8" cy="179.0" r="4.5"/>
+<text class="tx" x="720" y="183.0" font-size="10.5">+6.68  (8/8)</text>
 <text class="ti" x="156" y="211.2" font-size="11.5" text-anchor="end">Brush @ 15k</text>
-<line class="c1" x1="290.1" y1="207.2" x2="497.5" y2="207.2" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c1" x1="290.1" y1="203.2" x2="290.1" y2="211.2" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c1" x1="497.5" y1="203.2" x2="497.5" y2="211.2" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c1" cx="393.8" cy="207.2" r="4.5"/>
+<line class="c1" x1="290.6" y1="207.2" x2="497.4" y2="207.2" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c1" x1="290.6" y1="203.2" x2="290.6" y2="211.2" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c1" x1="497.4" y1="203.2" x2="497.4" y2="211.2" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c1" cx="394.0" cy="207.2" r="4.5"/>
 <text class="tx" x="720" y="211.2" font-size="10.5">+4.93  (8/8)</text>
 <text class="ti" x="156" y="239.4" font-size="11.5" text-anchor="end">msplat @ 500</text>
-<line class="c2" x1="445.9" y1="235.4" x2="555.6" y2="235.4" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c2" x1="445.9" y1="231.4" x2="445.9" y2="239.4" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c2" x1="555.6" y1="231.4" x2="555.6" y2="239.4" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c2" cx="500.7" cy="235.4" r="4.5"/>
-<text class="tx" x="720" y="239.4" font-size="10.5">+7.97  (8/8)</text>
+<line class="c2" x1="447.2" y1="235.4" x2="557.4" y2="235.4" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c2" x1="447.2" y1="231.4" x2="447.2" y2="239.4" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c2" x1="557.4" y1="231.4" x2="557.4" y2="239.4" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c2" cx="502.3" cy="235.4" r="4.5"/>
+<text class="tx" x="720" y="239.4" font-size="10.5">+8.01  (8/8)</text>
 <text class="ti" x="156" y="267.7" font-size="11.5" text-anchor="end">msplat @ 7k</text>
-<line class="c2" x1="410.3" y1="263.7" x2="608.6" y2="263.7" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c2" x1="410.3" y1="259.7" x2="410.3" y2="267.7" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c2" x1="608.6" y1="259.7" x2="608.6" y2="267.7" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c2" cx="509.5" cy="263.7" r="4.5"/>
-<text class="tx" x="720" y="267.7" font-size="10.5">+8.22  (8/8)</text>
+<line class="c2" x1="412.2" y1="263.7" x2="610.6" y2="263.7" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c2" x1="412.2" y1="259.7" x2="412.2" y2="267.7" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c2" x1="610.6" y1="259.7" x2="610.6" y2="267.7" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c2" cx="511.4" cy="263.7" r="4.5"/>
+<text class="tx" x="720" y="267.7" font-size="10.5">+8.27  (8/8)</text>
 <text class="ti" x="156" y="295.9" font-size="11.5" text-anchor="end">msplat @ 15k</text>
-<line class="c2" x1="486.6" y1="291.9" x2="676.9" y2="291.9" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
-<line class="c2" x1="486.6" y1="287.9" x2="486.6" y2="295.9" stroke-width="1.6" stroke-opacity="0.8"/>
-<line class="c2" x1="676.9" y1="287.9" x2="676.9" y2="295.9" stroke-width="1.6" stroke-opacity="0.8"/>
-<circle class="c2" cx="581.8" cy="291.9" r="4.5"/>
+<line class="c2" x1="487.3" y1="291.9" x2="676.8" y2="291.9" stroke-width="2.2" stroke-opacity="0.8" stroke-linecap="round"/>
+<line class="c2" x1="487.3" y1="287.9" x2="487.3" y2="295.9" stroke-width="1.6" stroke-opacity="0.8"/>
+<line class="c2" x1="676.8" y1="287.9" x2="676.8" y2="295.9" stroke-width="1.6" stroke-opacity="0.8"/>
+<circle class="c2" cx="582.1" cy="291.9" r="4.5"/>
 <text class="tx" x="720" y="295.9" font-size="10.5">+10.28  (8/8)</text>
 </svg>

--- a/bench/results/pareto_8scene.svg
+++ b/bench/results/pareto_8scene.svg
@@ -56,20 +56,20 @@
 <line class="ax" x1="62" y1="30" x2="62" y2="418"/>
 <text class="tx" x="366" y="458" font-size="12" text-anchor="middle">wall-clock (minutes, log scale)</text>
 <text class="tx" transform="translate(16,224) rotate(-90)" font-size="12" text-anchor="middle">PSNR (dB), 8-scene mean</text>
-<path class="s0" d="M201.4,232.6 L277.0,210.9 L326.8,148.7 L380.1,103.9 L427.0,77.0 L499.3,50.0" stroke-width="1" stroke-opacity="0.28"/>
-<path class="s0" d="M201.4,232.6 L277.0,210.9 L326.8,148.7 L380.1,103.9 L427.0,77.0 L499.3,50.0" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round" stroke-opacity="0.95"/>
-<line class="s0" x1="201.4" y1="247.5" x2="201.4" y2="217.7" stroke-width="1.2" stroke-opacity="0.5"/>
-<line class="s0" x1="277.0" y1="233.1" x2="277.0" y2="188.6" stroke-width="1.2" stroke-opacity="0.5"/>
-<line class="s0" x1="326.8" y1="169.1" x2="326.8" y2="128.3" stroke-width="1.2" stroke-opacity="0.5"/>
-<line class="s0" x1="380.1" y1="124.1" x2="380.1" y2="83.7" stroke-width="1.2" stroke-opacity="0.5"/>
-<line class="s0" x1="427.0" y1="98.8" x2="427.0" y2="55.2" stroke-width="1.2" stroke-opacity="0.5"/>
-<line class="s0" x1="499.3" y1="73.3" x2="499.3" y2="26.7" stroke-width="1.2" stroke-opacity="0.5"/>
-<circle class="f0" cx="201.4" cy="232.6" r="4"/>
-<circle class="f0" cx="277.0" cy="210.9" r="4"/>
-<circle class="f0" cx="326.8" cy="148.7" r="4"/>
-<circle class="f0" cx="380.1" cy="103.9" r="4"/>
-<circle class="f0" cx="427.0" cy="77.0" r="4"/>
-<circle class="f0" cx="499.3" cy="50.0" r="4"/>
+<path class="s0" d="M173.7,231.9 L269.4,210.5 L324.2,148.0 L380.2,103.7 L424.1,76.2 L498.8,49.9" stroke-width="1" stroke-opacity="0.28"/>
+<path class="s0" d="M173.7,231.9 L269.4,210.5 L324.2,148.0 L380.2,103.7 L424.1,76.2 L498.8,49.9" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round" stroke-opacity="0.95"/>
+<line class="s0" x1="173.7" y1="246.9" x2="173.7" y2="217.0" stroke-width="1.2" stroke-opacity="0.5"/>
+<line class="s0" x1="269.4" y1="232.6" x2="269.4" y2="188.5" stroke-width="1.2" stroke-opacity="0.5"/>
+<line class="s0" x1="324.2" y1="168.6" x2="324.2" y2="127.5" stroke-width="1.2" stroke-opacity="0.5"/>
+<line class="s0" x1="380.2" y1="124.5" x2="380.2" y2="83.0" stroke-width="1.2" stroke-opacity="0.5"/>
+<line class="s0" x1="424.1" y1="98.0" x2="424.1" y2="54.3" stroke-width="1.2" stroke-opacity="0.5"/>
+<line class="s0" x1="498.8" y1="73.3" x2="498.8" y2="26.6" stroke-width="1.2" stroke-opacity="0.5"/>
+<circle class="f0" cx="173.7" cy="231.9" r="4"/>
+<circle class="f0" cx="269.4" cy="210.5" r="4"/>
+<circle class="f0" cx="324.2" cy="148.0" r="4"/>
+<circle class="f0" cx="380.2" cy="103.7" r="4"/>
+<circle class="f0" cx="424.1" cy="76.2" r="4"/>
+<circle class="f0" cx="498.8" cy="49.9" r="4"/>
 <line class="s0" x1="678" y1="40" x2="696" y2="40" stroke-width="3"/>
 <text class="ti" x="702" y="44" font-size="12" font-weight="700">metal-gauss</text>
 <path class="s1" d="M212.6,369.1 L270.6,345.3 L348.1,305.8 L448.6,266.3 L549.0,224.9 L656.0,96.7" stroke-width="1" stroke-opacity="0.28"/>

--- a/bench/results/startup_cold.json
+++ b/bench/results/startup_cold.json
@@ -1,10 +1,10 @@
 {
   "schema": 1,
   "env": {
-    "git": "f0e2d68",
+    "git": "e820561",
     "dirty": true,
-    "torch": "2.13.0",
-    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "torch": "2.14.0",
+    "platform": "macOS-26.6.2-arm64-arm-64bit",
     "machine": "arm64"
   },
   "config": {
@@ -15,23 +15,23 @@
   },
   "rows": [
     {
-      "harness_s": 26.0,
-      "train_s": 17.6,
-      "startup_s": 8.4,
+      "harness_s": 20.1,
+      "train_s": 17.0,
+      "startup_s": 3.1,
       "run": 0,
       "ext_cold": true
     },
     {
-      "harness_s": 14.6,
-      "train_s": 5.9,
-      "startup_s": 8.7,
+      "harness_s": 8.1,
+      "train_s": 4.7,
+      "startup_s": 3.4,
       "run": 1,
       "ext_cold": false
     },
     {
-      "harness_s": 14.2,
-      "train_s": 5.6,
-      "startup_s": 8.6,
+      "harness_s": 7.7,
+      "train_s": 4.7,
+      "startup_s": 3.0,
       "run": 2,
       "ext_cold": false
     }

--- a/bench/results/startup_warm.json
+++ b/bench/results/startup_warm.json
@@ -1,10 +1,10 @@
 {
   "schema": 1,
   "env": {
-    "git": "f0e2d68",
+    "git": "e820561",
     "dirty": true,
-    "torch": "2.13.0",
-    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "torch": "2.14.0",
+    "platform": "macOS-26.6.2-arm64-arm-64bit",
     "machine": "arm64"
   },
   "config": {
@@ -15,30 +15,30 @@
   },
   "rows": [
     {
-      "harness_s": 14.2,
-      "train_s": 5.5,
-      "startup_s": 8.7,
+      "harness_s": 8.0,
+      "train_s": 4.7,
+      "startup_s": 3.3,
       "run": 0,
       "ext_cold": false
     },
     {
-      "harness_s": 13.8,
-      "train_s": 5.5,
-      "startup_s": 8.3,
+      "harness_s": 7.8,
+      "train_s": 4.6,
+      "startup_s": 3.2,
       "run": 1,
       "ext_cold": false
     },
     {
-      "harness_s": 14.0,
-      "train_s": 5.6,
-      "startup_s": 8.4,
+      "harness_s": 7.7,
+      "train_s": 4.6,
+      "startup_s": 3.1,
       "run": 2,
       "ext_cold": false
     },
     {
-      "harness_s": 13.9,
-      "train_s": 5.6,
-      "startup_s": 8.3,
+      "harness_s": 7.8,
+      "train_s": 4.9,
+      "startup_s": 2.9,
       "run": 3,
       "ext_cold": false
     }

--- a/bench/results/sweep8/chair_metal-gauss.json
+++ b/bench/results/sweep8/chair_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/chair",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 17.8,
+      "wall_s": 12.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpqr3zpq95.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmphdwhxczj.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 22.3188,
-      "ssim": 0.86445,
+      "psnr": 22.305,
+      "ssim": 0.86451,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 40.7,
+      "wall_s": 35.2,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpz2cyz40y.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmplp5e2986.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 21.564,
-      "ssim": 0.88798,
+      "psnr": 21.6246,
+      "ssim": 0.8883,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 66.5,
+      "wall_s": 59.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpe976ggs6.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpfs5ceny6.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 26.4081,
-      "ssim": 0.93021,
+      "psnr": 26.3139,
+      "ssim": 0.93006,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 108.7,
+      "wall_s": 98.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpv6skmbvb.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpgzjseibz.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.097,
-      "ssim": 0.95885,
+      "psnr": 30.0694,
+      "ssim": 0.95913,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 164.4,
+      "wall_s": 150.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpg8ze4pg0.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpo8giz6rw.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 32.5019,
-      "ssim": 0.97152,
+      "psnr": 32.5624,
+      "ssim": 0.97169,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 325.4,
+      "wall_s": 301.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/chair",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/chair",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp79mnmqvn.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpch1kez77.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 34.5489,
-      "ssim": 0.98195,
+      "psnr": 34.5699,
+      "ssim": 0.98211,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/drums_metal-gauss.json
+++ b/bench/results/sweep8/drums_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/drums",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 17.4,
+      "wall_s": 14.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmptyqrjv2b.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpwe0mrqj6.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 18.6353,
-      "ssim": 0.83264,
+      "psnr": 18.6422,
+      "ssim": 0.83295,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 36.4,
+      "wall_s": 38.9,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpw4layjsy.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpo7ydtd2c.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 20.3615,
-      "ssim": 0.87496,
+      "psnr": 20.4765,
+      "ssim": 0.8761,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 58.9,
+      "wall_s": 67.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpt1udi7ca.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpyjxe2k5d.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 22.5738,
-      "ssim": 0.91124,
+      "psnr": 22.6866,
+      "ssim": 0.91197,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 100.5,
+      "wall_s": 114.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmprrhozslo.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp0tdrxigt.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 24.1489,
-      "ssim": 0.93207,
+      "psnr": 24.1554,
+      "ssim": 0.93247,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 157.6,
+      "wall_s": 189.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpa3bu_2qc.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmptz0nufc0.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 24.9292,
-      "ssim": 0.94172,
+      "psnr": 24.9282,
+      "ssim": 0.94168,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 317.1,
+      "wall_s": 339.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/drums",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/drums",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpnltmx5mz.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpe4egwuid.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 25.5825,
-      "ssim": 0.94957,
+      "psnr": 25.5959,
+      "ssim": 0.94972,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/ficus_metal-gauss.json
+++ b/bench/results/sweep8/ficus_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/ficus",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 16.9,
+      "wall_s": 12.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpwprp7p8_.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpg2r25v60.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 21.3348,
-      "ssim": 0.87787,
+      "psnr": 21.4134,
+      "ssim": 0.87815,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 42.3,
+      "wall_s": 39.4,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpwk8fcutl.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp189sf145.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 19.2909,
-      "ssim": 0.8923,
+      "psnr": 19.161,
+      "ssim": 0.89093,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 65.3,
+      "wall_s": 59.1,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmph171vb4y.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp6l8j15_4.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 24.1941,
-      "ssim": 0.94282,
+      "psnr": 24.0499,
+      "ssim": 0.94241,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 101.6,
+      "wall_s": 108.6,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp9w5wq1c8.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpf28nd6eu.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 27.4138,
-      "ssim": 0.96709,
+      "psnr": 27.2684,
+      "ssim": 0.96626,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 154.9,
+      "wall_s": 143.6,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpprjjbg93.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp98ih43pa.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 28.6482,
-      "ssim": 0.9734,
+      "psnr": 28.7081,
+      "ssim": 0.97368,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 311.5,
+      "wall_s": 293.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ficus",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ficus",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpb4szck0s.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpnsmg30pb.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.597,
-      "ssim": 0.97961,
+      "psnr": 30.5405,
+      "ssim": 0.97953,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/hotdog_metal-gauss.json
+++ b/bench/results/sweep8/hotdog_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/hotdog",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 18.3,
+      "wall_s": 13.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpczwwa5dc.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpaxx86pg2.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 24.8108,
-      "ssim": 0.91043,
+      "psnr": 24.87,
+      "ssim": 0.91064,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 40.3,
+      "wall_s": 34.7,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpbez5s0lu.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpnz6pdxqq.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.4535,
-      "ssim": 0.95188,
+      "psnr": 30.4195,
+      "ssim": 0.95173,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 72.2,
+      "wall_s": 64.4,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpiwuusxq1.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp42ju3e8e.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 33.0557,
-      "ssim": 0.96657,
+      "psnr": 33.0855,
+      "ssim": 0.96693,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 128.8,
+      "wall_s": 117.6,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpu3bro0bw.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpi38u_4xh.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 34.9384,
-      "ssim": 0.97563,
+      "psnr": 35.1142,
+      "ssim": 0.97599,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 206.6,
+      "wall_s": 191.4,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp2nky7oc8.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpdknjnu6d.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 36.4827,
-      "ssim": 0.98071,
+      "psnr": 36.5223,
+      "ssim": 0.98066,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 416.0,
+      "wall_s": 429.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/hotdog",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/hotdog",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpfnimmcon.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp1_d7kowq.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,13 +347,13 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 37.7372,
+      "psnr": 37.7616,
       "ssim": 0.98486,
       "n_splats": 100000
     }

--- a/bench/results/sweep8/lego_metal-gauss.json
+++ b/bench/results/sweep8/lego_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/lego",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 18.8,
+      "wall_s": 16.2,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp8up3wqm2.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpcxsoine3.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 20.4894,
-      "ssim": 0.80351,
+      "psnr": 20.4977,
+      "ssim": 0.80392,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 39.9,
+      "wall_s": 36.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp9p5ah1en.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpl8ppydts.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 23.7912,
-      "ssim": 0.85903,
+      "psnr": 23.6135,
+      "ssim": 0.85758,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 66.1,
+      "wall_s": 63.7,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpuhxtalv3.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmph70tavc0.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 26.145,
-      "ssim": 0.90021,
+      "psnr": 26.2797,
+      "ssim": 0.90078,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 112.4,
+      "wall_s": 121.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpuvllb2o7.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpyiysua8f.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 28.7999,
-      "ssim": 0.93364,
+      "psnr": 28.8706,
+      "ssim": 0.9333,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 178.3,
+      "wall_s": 188.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpaervbbx6.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp9g_ns3eg.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.5955,
-      "ssim": 0.95113,
+      "psnr": 30.7131,
+      "ssim": 0.9513,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 355.7,
+      "wall_s": 397.3,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/lego",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/lego",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpxnzmtim6.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpt6hnwjp5.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "a78eb15",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 32.9734,
-      "ssim": 0.96918,
+      "psnr": 33.0255,
+      "ssim": 0.9695,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/logs/chair_metal-gauss.log
+++ b/bench/results/sweep8/logs/chair_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.30 min        22.319 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.68 min        21.564 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.11 min        26.408 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.81 min        30.097 dB    100,000 splats
-  metal-gauss    7000 b=100k    2.74 min        32.502 dB    100,000 splats
-  metal-gauss   15000 b=100k    5.42 min        34.549 dB    100,000 splats
+  metal-gauss     500 b=30k    0.21 min        22.305 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.59 min        21.625 dB    100,000 splats
+  metal-gauss    2000 b=100k    0.99 min        26.314 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.64 min        30.069 dB    100,000 splats
+  metal-gauss    7000 b=100k    2.51 min        32.562 dB    100,000 splats
+  metal-gauss   15000 b=100k    5.02 min        34.570 dB    100,000 splats
 
--> bench/results/sweep8/chair_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/chair_metal-gauss.json

--- a/bench/results/sweep8/logs/drums_metal-gauss.log
+++ b/bench/results/sweep8/logs/drums_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.29 min        18.635 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.61 min        20.361 dB    100,000 splats
-  metal-gauss    2000 b=100k    0.98 min        22.574 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.67 min        24.149 dB    100,000 splats
-  metal-gauss    7000 b=100k    2.63 min        24.929 dB    100,000 splats
-  metal-gauss   15000 b=100k    5.29 min        25.582 dB    100,000 splats
+  metal-gauss     500 b=30k    0.25 min        18.642 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.65 min        20.477 dB    100,000 splats
+  metal-gauss    2000 b=100k    1.12 min        22.687 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.91 min        24.155 dB    100,000 splats
+  metal-gauss    7000 b=100k    3.16 min        24.928 dB    100,000 splats
+  metal-gauss   15000 b=100k    5.66 min        25.596 dB    100,000 splats
 
--> bench/results/sweep8/drums_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/drums_metal-gauss.json

--- a/bench/results/sweep8/logs/ficus_metal-gauss.log
+++ b/bench/results/sweep8/logs/ficus_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.28 min        21.335 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.71 min        19.291 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.09 min        24.194 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.69 min        27.414 dB    100,000 splats
-  metal-gauss    7000 b=100k    2.58 min        28.648 dB    100,000 splats
-  metal-gauss   15000 b=100k    5.19 min        30.597 dB    100,000 splats
+  metal-gauss     500 b=30k    0.21 min        21.413 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.66 min        19.161 dB    100,000 splats
+  metal-gauss    2000 b=100k    0.98 min        24.050 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.81 min        27.268 dB    100,000 splats
+  metal-gauss    7000 b=100k    2.39 min        28.708 dB    100,000 splats
+  metal-gauss   15000 b=100k    4.89 min        30.541 dB    100,000 splats
 
--> bench/results/sweep8/ficus_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/ficus_metal-gauss.json

--- a/bench/results/sweep8/logs/hotdog_metal-gauss.log
+++ b/bench/results/sweep8/logs/hotdog_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.31 min        24.811 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.67 min        30.453 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.20 min        33.056 dB    100,000 splats
-  metal-gauss    4000 b=100k    2.15 min        34.938 dB    100,000 splats
-  metal-gauss    7000 b=100k    3.44 min        36.483 dB    100,000 splats
-  metal-gauss   15000 b=100k    6.93 min        37.737 dB    100,000 splats
+  metal-gauss     500 b=30k    0.23 min        24.870 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.58 min        30.419 dB    100,000 splats
+  metal-gauss    2000 b=100k    1.07 min        33.086 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.96 min        35.114 dB    100,000 splats
+  metal-gauss    7000 b=100k    3.19 min        36.522 dB    100,000 splats
+  metal-gauss   15000 b=100k    7.15 min        37.762 dB    100,000 splats
 
--> bench/results/sweep8/hotdog_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/hotdog_metal-gauss.json

--- a/bench/results/sweep8/logs/lego_metal-gauss.log
+++ b/bench/results/sweep8/logs/lego_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.31 min        20.489 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.66 min        23.791 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.10 min        26.145 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.87 min        28.800 dB    100,000 splats
-  metal-gauss    7000 b=100k    2.97 min        30.596 dB    100,000 splats
-  metal-gauss   15000 b=100k    5.93 min        32.973 dB    100,000 splats
+  metal-gauss     500 b=30k    0.27 min        20.498 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.61 min        23.613 dB    100,000 splats
+  metal-gauss    2000 b=100k    1.06 min        26.280 dB    100,000 splats
+  metal-gauss    4000 b=100k    2.02 min        28.871 dB    100,000 splats
+  metal-gauss    7000 b=100k    3.15 min        30.713 dB    100,000 splats
+  metal-gauss   15000 b=100k    6.62 min        33.026 dB    100,000 splats
 
--> bench/results/sweep8/lego_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/lego_metal-gauss.json

--- a/bench/results/sweep8/logs/materials_metal-gauss.log
+++ b/bench/results/sweep8/logs/materials_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.29 min        19.661 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.60 min        20.184 dB    100,000 splats
-  metal-gauss    2000 b=100k    0.96 min        23.369 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.75 min        26.029 dB    100,000 splats
-  metal-gauss    7000 b=100k    3.17 min        27.904 dB    100,000 splats
-  metal-gauss   15000 b=100k    6.87 min        29.438 dB    100,000 splats
+  metal-gauss     500 b=30k    0.23 min        19.718 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.56 min        20.238 dB    100,000 splats
+  metal-gauss    2000 b=100k    0.96 min        23.330 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.51 min        25.889 dB    100,000 splats
+  metal-gauss    7000 b=100k    2.42 min        27.940 dB    100,000 splats
+  metal-gauss   15000 b=100k    5.68 min        29.436 dB    100,000 splats
 
--> bench/results/sweep8/materials_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/materials_metal-gauss.json

--- a/bench/results/sweep8/logs/mic_metal-gauss.log
+++ b/bench/results/sweep8/logs/mic_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.32 min        25.090 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.64 min        21.992 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.04 min        27.905 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.72 min        30.523 dB    100,000 splats
-  metal-gauss    7000 b=100k    2.65 min        32.324 dB    100,000 splats
-  metal-gauss   15000 b=100k    5.54 min        34.005 dB    100,000 splats
+  metal-gauss     500 b=30k    0.22 min        25.127 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.62 min        22.387 dB    100,000 splats
+  metal-gauss    2000 b=100k    1.03 min        28.060 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.78 min        30.633 dB    100,000 splats
+  metal-gauss    7000 b=100k    2.53 min        32.313 dB    100,000 splats
+  metal-gauss   15000 b=100k    5.35 min        33.978 dB    100,000 splats
 
--> bench/results/sweep8/mic_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/mic_metal-gauss.json

--- a/bench/results/sweep8/logs/ship_metal-gauss.log
+++ b/bench/results/sweep8/logs/ship_metal-gauss.log
@@ -1,8 +1,8 @@
-  metal-gauss     500 b=30k    0.36 min        19.763 dB     27,857 splats
-  metal-gauss    1000 b=100k    0.65 min        24.314 dB    100,000 splats
-  metal-gauss    2000 b=100k    1.08 min        26.505 dB    100,000 splats
-  metal-gauss    4000 b=100k    1.89 min        28.530 dB    100,000 splats
-  metal-gauss    7000 b=100k    3.05 min        29.289 dB    100,000 splats
-  metal-gauss   15000 b=100k    6.56 min        30.063 dB    100,000 splats
+  metal-gauss     500 b=30k    0.25 min        19.840 dB     27,857 splats
+  metal-gauss    1000 b=100k    0.58 min        24.196 dB    100,000 splats
+  metal-gauss    2000 b=100k    1.11 min        26.649 dB    100,000 splats
+  metal-gauss    4000 b=100k    1.94 min        28.550 dB    100,000 splats
+  metal-gauss    7000 b=100k    3.22 min        29.377 dB    100,000 splats
+  metal-gauss   15000 b=100k    7.10 min        30.050 dB    100,000 splats
 
--> bench/results/sweep8/ship_metal-gauss.json
+-> /private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/bench/results/sweep8/ship_metal-gauss.json

--- a/bench/results/sweep8/materials_metal-gauss.json
+++ b/bench/results/sweep8/materials_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/materials",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 17.6,
+      "wall_s": 14.0,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpx5k3g2bl.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp4qud8f_l.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 19.6614,
-      "ssim": 0.82597,
+      "psnr": 19.7177,
+      "ssim": 0.82652,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 36.1,
+      "wall_s": 33.9,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp6puxby_q.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpckfkx44p.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 20.1844,
-      "ssim": 0.85598,
+      "psnr": 20.238,
+      "ssim": 0.85569,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 57.5,
+      "wall_s": 57.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpvdizsa0t.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp3b3o9u89.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 23.3689,
-      "ssim": 0.89888,
+      "psnr": 23.3301,
+      "ssim": 0.89825,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 104.9,
+      "wall_s": 90.7,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp1pq11358.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmplnftef4z.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 26.0287,
-      "ssim": 0.93235,
+      "psnr": 25.8886,
+      "ssim": 0.93219,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 190.2,
+      "wall_s": 145.2,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpxl87f4du.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpmwla54_b.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 27.904,
-      "ssim": 0.94757,
+      "psnr": 27.9401,
+      "ssim": 0.94768,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 412.0,
+      "wall_s": 340.7,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/materials",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/materials",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpsetmk88l.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp9n16dmtf.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 29.4379,
-      "ssim": 0.95833,
+      "psnr": 29.4356,
+      "ssim": 0.95831,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/mic_metal-gauss.json
+++ b/bench/results/sweep8/mic_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/mic",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 19.1,
+      "wall_s": 13.1,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpdf_o7mlg.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpphdb0c_r.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 25.0902,
-      "ssim": 0.93539,
+      "psnr": 25.1273,
+      "ssim": 0.9354,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 38.3,
+      "wall_s": 37.1,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmplsrx745i.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmps3fdrknq.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 21.992,
-      "ssim": 0.93711,
+      "psnr": 22.3875,
+      "ssim": 0.93839,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 62.4,
+      "wall_s": 62.0,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmppo5j842a.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpslmfq_25.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 27.9047,
-      "ssim": 0.96237,
+      "psnr": 28.0602,
+      "ssim": 0.96195,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 103.0,
+      "wall_s": 106.9,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp333dxacx.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp_seujlwl.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.5229,
-      "ssim": 0.97557,
+      "psnr": 30.6334,
+      "ssim": 0.97592,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 159.1,
+      "wall_s": 151.6,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpdnx6v7e7.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmplmwg7t7q.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 32.3241,
-      "ssim": 0.98319,
+      "psnr": 32.3128,
+      "ssim": 0.98324,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 332.4,
+      "wall_s": 320.8,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/mic",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/mic",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpcysy6vvp.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpcyvftzp7.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 34.0051,
-      "ssim": 0.98849,
+      "psnr": 33.9783,
+      "ssim": 0.98829,
       "n_splats": 100000
     }
   ]

--- a/bench/results/sweep8/ship_metal-gauss.json
+++ b/bench/results/sweep8/ship_metal-gauss.json
@@ -1,5 +1,5 @@
 {
-  "scene": "data/nerf_synthetic/ship",
+  "scene": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
   "resolution": 800,
   "msplat_variant": "scaled",
   "rows": [
@@ -8,12 +8,12 @@
       "iters": 500,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 21.6,
+      "wall_s": 15.2,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 30000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -40,7 +40,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpgc_xksya.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpw6pt5scv.report.json",
         "resolution_schedule": 166,
         "scale_reg": 0.01,
         "seed": 0,
@@ -52,14 +52,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 19.7632,
-      "ssim": 0.74812,
+      "psnr": 19.8403,
+      "ssim": 0.74902,
       "n_splats": 27857
     },
     {
@@ -67,12 +67,12 @@
       "iters": 1000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 38.9,
+      "wall_s": 34.6,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -99,7 +99,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpqacel4zs.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp1_pu5hnv.report.json",
         "resolution_schedule": 333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -111,14 +111,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 24.3145,
-      "ssim": 0.81649,
+      "psnr": 24.1957,
+      "ssim": 0.81488,
       "n_splats": 100000
     },
     {
@@ -126,12 +126,12 @@
       "iters": 2000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 64.8,
+      "wall_s": 66.7,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -158,7 +158,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpbi3yis85.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpo0uz22w1.report.json",
         "resolution_schedule": 666,
         "scale_reg": 0.01,
         "seed": 0,
@@ -170,14 +170,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 26.5052,
-      "ssim": 0.85129,
+      "psnr": 26.6487,
+      "ssim": 0.85247,
       "n_splats": 100000
     },
     {
@@ -185,12 +185,12 @@
       "iters": 4000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 113.5,
+      "wall_s": 116.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -217,7 +217,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp5h141wsp.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp1kkfab2d.report.json",
         "resolution_schedule": 1333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -229,14 +229,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 28.5305,
-      "ssim": 0.87622,
+      "psnr": 28.5501,
+      "ssim": 0.87646,
       "n_splats": 100000
     },
     {
@@ -244,12 +244,12 @@
       "iters": 7000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 182.8,
+      "wall_s": 193.5,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -276,7 +276,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmp2nauqltg.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmplr3bhrx0.report.json",
         "resolution_schedule": 2333,
         "scale_reg": 0.01,
         "seed": 0,
@@ -288,14 +288,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 29.2892,
-      "ssim": 0.88694,
+      "psnr": 29.3766,
+      "ssim": 0.88744,
       "n_splats": 100000
     },
     {
@@ -303,12 +303,12 @@
       "iters": 15000,
       "requested_budget": "auto",
       "ok": true,
-      "wall_s": 393.6,
+      "wall_s": 426.0,
       "resolved": {
         "antialias": false,
         "appearance": "off",
         "appearance_reg": 0.01,
-        "blender": "data/nerf_synthetic/ship",
+        "blender": "/private/tmp/claude-501/-Users-metzgern/d957f3bf-ebf5-45b7-b9dd-ff9331200be5/scratchpad/mg/data/nerf_synthetic/ship",
         "budget": 100000,
         "colmap": null,
         "densify_gate_frac": 0.3,
@@ -335,7 +335,7 @@
         "out": null,
         "relocate_every": 100,
         "relocate_until_frac": 0.85,
-        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpcf40025t.report.json",
+        "report": "/var/folders/28/jp1bnbdx18zclmsr7zzsfdk40000gn/T/tmpdr579s2w.report.json",
         "resolution_schedule": 5000,
         "scale_reg": 0.01,
         "seed": 0,
@@ -347,14 +347,14 @@
         "steps_scaler": 1.0
       },
       "env": {
-        "git": "72a6a3b",
+        "git": "c607668",
         "dirty": true,
-        "torch": "2.13.0",
-        "platform": "macOS-26.5.2-arm64-arm-64bit",
+        "torch": "2.14.0",
+        "platform": "macOS-26.6.2-arm64-arm-64bit",
         "machine": "arm64"
       },
-      "psnr": 30.0628,
-      "ssim": 0.89873,
+      "psnr": 30.0501,
+      "ssim": 0.8988,
       "n_splats": 100000
     }
   ]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -61,15 +61,15 @@ The README carries this as a forest plot; these are the numbers behind it.
 <!-- BEGIN:margin -->
 | vs | iters | mean Δ | 95% CI | scenes won |
 |---|---:|---:|---|---:|
-| spirula-studio | 500 | +7.74 dB | [+6.25, +9.23] | 8/8 |
-| spirula-studio | 7,000 | +8.39 dB | [+5.43, +11.34] | 8/8 |
-| spirula-studio | 15,000 | +2.65 dB | **[-0.13, +5.43]** — includes 0 | 7/8 |
-| Brush | 500 | +8.67 dB | [+6.10, +11.23] | 8/8 |
-| Brush | 7,000 | +6.64 dB | [+4.20, +9.07] | 8/8 |
-| Brush | 15,000 | +4.93 dB | [+1.97, +7.88] | 8/8 |
-| msplat | 500 | +7.97 dB | [+6.41, +9.53] | 8/8 |
-| msplat | 7,000 | +8.22 dB | [+5.40, +11.04] | 8/8 |
-| msplat | 15,000 | +10.28 dB | [+7.57, +12.98] | 8/8 |
+| spirula-studio | 500 | +7.78 dB | [+6.29, +9.27] | 8/8 |
+| spirula-studio | 7,000 | +8.43 dB | [+5.47, +11.39] | 8/8 |
+| spirula-studio | 15,000 | +2.65 dB | **[-0.13, +5.44]** — includes 0 | 7/8 |
+| Brush | 500 | +8.70 dB | [+6.12, +11.29] | 8/8 |
+| Brush | 7,000 | +6.68 dB | [+4.26, +9.11] | 8/8 |
+| Brush | 15,000 | +4.93 dB | [+1.99, +7.87] | 8/8 |
+| msplat | 500 | +8.01 dB | [+6.44, +9.58] | 8/8 |
+| msplat | 7,000 | +8.27 dB | [+5.45, +11.09] | 8/8 |
+| msplat | 15,000 | +10.28 dB | [+7.58, +12.97] | 8/8 |
 
 *Per-scene difference across all 8 scenes, 95% CI from Student-t (df 7). A CI containing zero means the quality margin at that point is not resolved by 8 scenes, whatever the mean says.*
 <!-- END:margin -->
@@ -85,35 +85,35 @@ Every implementation at every rung, sorted by wall-clock. The README carries the
 | msplat (stock) | 500 | 0.10 min | 12.06 | 0.7986 |
 | msplat (stock) | 2,000 | 0.15 min | 19.65 | 0.8537 |
 | msplat (stock) | 1,000 | 0.16 min | 13.50 | 0.8108 |
-| metal-gauss | 500 | 0.31 min | 21.51 | 0.8498 |
+| metal-gauss | 500 | 0.23 min | 21.55 | 0.8501 |
 | msplat (stock) | 4,000 | 0.34 min | 19.13 | 0.8754 |
 | spirula-studio | 500 | 0.34 min | 13.77 | 0.8167 |
 | brush | 500 | 0.43 min | 12.85 | 0.7967 |
 | msplat (scaled) | 500 | 0.44 min | 13.54 | 0.8113 |
+| metal-gauss | 1,000 | 0.60 min | 22.76 | 0.8842 |
 | spirula-studio | 1,000 | 0.61 min | 15.12 | 0.8328 |
-| metal-gauss | 1,000 | 0.65 min | 22.74 | 0.8845 |
 | msplat (scaled) | 2,000 | 0.73 min | 18.26 | 0.8690 |
 | brush | 1,000 | 0.79 min | 14.35 | 0.8042 |
 | msplat (scaled) | 1,000 | 0.88 min | 17.53 | 0.8330 |
 | msplat (stock) | 7,000 | 0.90 min | 21.19 | 0.9067 |
-| metal-gauss | 2,000 | 1.07 min | 26.27 | 0.9204 |
+| metal-gauss | 2,000 | 1.04 min | 26.31 | 0.9206 |
 | spirula-studio | 2,000 | 1.32 min | 17.36 | 0.8665 |
 | brush | 2,000 | 1.58 min | 18.44 | 0.8340 |
 | msplat (scaled) | 4,000 | 1.59 min | 20.22 | 0.8977 |
-| metal-gauss | 4,000 | 1.82 min | 28.81 | 0.9439 |
+| metal-gauss | 4,000 | 1.82 min | 28.82 | 0.9440 |
 | msplat (scaled) | 7,000 | 2.74 min | 20.60 | 0.9021 |
-| metal-gauss | 7,000 | 2.90 min | 30.33 | 0.9545 |
+| metal-gauss | 7,000 | 2.82 min | 30.38 | 0.9547 |
 | brush | 4,000 | 3.19 min | 21.37 | 0.8677 |
 | spirula-studio | 4,000 | 3.60 min | 19.60 | 0.8973 |
 | msplat (stock) | 15,000 | 4.14 min | 20.58 | 0.9084 |
 | brush | 7,000 | 5.67 min | 23.70 | 0.8979 |
 | msplat (scaled) | 15,000 | 5.78 min | 21.04 | 0.9084 |
-| metal-gauss | 15,000 | 5.97 min | 31.87 | 0.9638 |
+| metal-gauss | 15,000 | 5.93 min | 31.87 | 0.9639 |
 | spirula-studio | 7,000 | 9.78 min | 21.95 | 0.9082 |
 | brush | 15,000 | 12.57 min | 26.94 | 0.9358 |
 | spirula-studio | 15,000 | 28.38 min | 29.22 | 0.9506 |
 
-*All 8 NeRF-synthetic scenes, official 200-view test split, one evaluator, identical seed point cloud per scene, strictly sequential. metal-gauss dominates (faster **and** better on PSNR / on PSNR **and** SSIM): **48/48** / **48/48** of Brush, **45/48** / **41/48** of spirula-studio, **66/96** / **50/96** of msplat (both variants). Single runs per cell; noise floors differ per implementation AND per scene (see NEGATIVE_RESULTS.md): metal-gauss 0.22 dB, spirula 0.15-1.27, Brush 0.74, msplat up to 3.35 -- msplat's counts are indicative only.*
+*All 8 NeRF-synthetic scenes, official 200-view test split, one evaluator, identical seed point cloud per scene, strictly sequential. metal-gauss dominates (faster **and** better on PSNR / on PSNR **and** SSIM): **48/48** / **48/48** of Brush, **47/48** / **45/48** of spirula-studio, **68/96** / **51/96** of msplat (both variants). Single runs per cell; noise floors differ per implementation AND per scene (see NEGATIVE_RESULTS.md): metal-gauss 0.22 dB, spirula 0.15-1.27, Brush 0.74, msplat up to 3.35 -- msplat's counts are indicative only.*
 <!-- END:pareto-scenes -->
 
 ## lego, as a worked example

--- a/metal_gauss/blender.py
+++ b/metal_gauss/blender.py
@@ -24,60 +24,93 @@ from __future__ import annotations
 
 import json
 import math
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
 import torch
 
-from metal_gauss.dataset import Scene, View
+from metal_gauss.dataset import LazyViews, Scene, View
 
 # OpenGL -> OpenCV: negate the y and z basis vectors.
 _GL2CV = np.diag([1.0, -1.0, -1.0, 1.0]).astype(np.float32)
 
 
-def _load_split(root: Path, split: str, max_resolution: int) -> list[View]:
-    from PIL import Image
+def _frames(root: Path, split: str) -> tuple[float, list[tuple[Path, dict]]]:
+    """Everything about a split that can be known without decoding a pixel.
 
+    Existence filtering happens here so a caller can be told how many views a
+    split has -- and be told the truth about a scene with missing files --
+    while the images themselves are still on disk.
+    """
     meta = json.loads((root / f"transforms_{split}.json").read_text())
     angle_x = float(meta["camera_angle_x"])
-    views: list[View] = []
-
+    out = []
     for fr in meta["frames"]:
         p = root / (fr["file_path"].lstrip("./") + ".png")
-        if not p.exists():
-            continue
-        img = Image.open(p)
-        scale = min(1.0, max_resolution / max(img.size))
-        W, H = int(round(img.width * scale)), int(round(img.height * scale))
-        if (W, H) != img.size:
-            img = img.resize((W, H), Image.LANCZOS)
+        if p.exists():
+            out.append((p, fr))
+    return angle_x, out
 
-        a = np.asarray(img, dtype=np.float32) / 255.0
-        if a.shape[-1] == 4:                       # composite over white
-            rgb = a[..., :3] * a[..., 3:4] + (1.0 - a[..., 3:4])
-        else:
-            rgb = a[..., :3]
 
-        focal = 0.5 * W / math.tan(0.5 * angle_x)
-        K = torch.tensor([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1.0]],
-                         dtype=torch.float32)
+def _decode(p: Path, fr: dict, angle_x: float, max_resolution: int) -> View:
+    from PIL import Image
 
-        c2w = np.array(fr["transform_matrix"], dtype=np.float32) @ _GL2CV
-        vm = torch.from_numpy(np.linalg.inv(c2w).astype(np.float32))
+    img = Image.open(p)
+    scale = min(1.0, max_resolution / max(img.size))
+    W, H = int(round(img.width * scale)), int(round(img.height * scale))
+    if (W, H) != img.size:
+        img = img.resize((W, H), Image.LANCZOS)
 
-        views.append(View(p.name,
-                          torch.from_numpy((rgb * 255).astype(np.uint8)),
-                          K, vm))
-    return views
+    a = np.asarray(img, dtype=np.float32) / 255.0
+    if a.shape[-1] == 4:                       # composite over white
+        rgb = a[..., :3] * a[..., 3:4] + (1.0 - a[..., 3:4])
+    else:
+        rgb = a[..., :3]
+
+    focal = 0.5 * W / math.tan(0.5 * angle_x)
+    K = torch.tensor([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1.0]],
+                     dtype=torch.float32)
+
+    c2w = np.array(fr["transform_matrix"], dtype=np.float32) @ _GL2CV
+    vm = torch.from_numpy(np.linalg.inv(c2w).astype(np.float32))
+    return View(p.name, torch.from_numpy((rgb * 255).astype(np.uint8)), K, vm)
+
+
+def _decode_all(angle_x: float, frames: list[tuple[Path, dict]],
+                max_resolution: int) -> list[View]:
+    """Decode a split in parallel, in JSON order.
+
+    PIL releases the GIL for both decode and resize, so this is a real 3.4x on
+    ten cores. Order is the map's, not completion order: the trainer indexes
+    the training list with a seeded permutation, so a reordering here would
+    silently change which views a "reproducible" run trains on.
+    """
+    if not frames:
+        return []
+    workers = min(8, len(frames), os.cpu_count() or 1)
+    if workers == 1:
+        return [_decode(p, fr, angle_x, max_resolution) for p, fr in frames]
+    with ThreadPoolExecutor(workers) as pool:
+        return list(pool.map(
+            lambda a: _decode(a[0], a[1], angle_x, max_resolution), frames))
 
 
 def load_blender(root: str | Path, max_resolution: int = 800,
                  n_init: int = 100_000, seed: int = 0) -> Scene:
     root = Path(root)
-    train = _load_split(root, "train", max_resolution)
-    heldout = _load_split(root, "test", max_resolution)
+    train_angle, train_frames = _frames(root, "train")
+    test_angle, test_frames = _frames(root, "test")
+    train = _decode_all(train_angle, train_frames, max_resolution)
     if not train:
         raise FileNotFoundError(f"no training frames under {root}")
+
+    # Held out until something asks. A benchmark run with `eval_every` past
+    # `steps` never does, and on lego that is 200 images and 4.1 s.
+    heldout = LazyViews(
+        len(test_frames),
+        lambda: _decode_all(test_angle, test_frames, max_resolution))
 
     # No sparse cloud in these scenes. The 3DGS papers initialise from a
     # uniform cube; its extent is set from the camera ring so the scale is not

--- a/metal_gauss/dataset.py
+++ b/metal_gauss/dataset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,10 +60,46 @@ def downscaled(v: View, factor: int) -> View:
     return out
 
 
+class LazyViews(Sequence):
+    """Views whose count is known now and whose pixels are decoded on demand.
+
+    The held-out split of a Blender scene is 200 images, twice the training
+    set, and a run that never evaluates never reads one of them -- but decoding
+    them was 4.1 s of a 8.7 s startup. Counting frames needs only the JSON, so
+    length is answered without touching a PNG.
+
+    Materialisation happens once and the resulting View objects are kept:
+    `downscaled()` caches its pyramid on `id(view)`, so handing out fresh
+    objects per access would silently defeat that cache.
+    """
+
+    def __init__(self, count: int, materialise):
+        self._count = count
+        self._materialise = materialise
+        self._views: list[View] | None = None
+
+    def _all(self) -> list[View]:
+        if self._views is None:
+            self._views = self._materialise()
+            if len(self._views) != self._count:
+                raise RuntimeError(
+                    f"expected {self._count} views, decoded {len(self._views)}")
+        return self._views
+
+    def __len__(self) -> int:
+        return self._count
+
+    def __getitem__(self, i):
+        return self._all()[i]
+
+    def __iter__(self):
+        return iter(self._all())
+
+
 @dataclass
 class Scene:
-    train: list[View]
-    heldout: list[View]
+    train: Sequence[View]
+    heldout: Sequence[View]
     points: np.ndarray       # (P,3) sparse init
     colors: np.ndarray       # (P,3) in [0,1]
 

--- a/tests/test_blender_loading.py
+++ b/tests/test_blender_loading.py
@@ -1,0 +1,139 @@
+"""Loading a Blender scene: what gets decoded, when, and that it is unchanged.
+
+Startup was 8.7 s on lego, of which 6.1 s was PNG decode -- and 4.1 s of that
+decoded the 200 held-out views, which a run with no evaluation never reads.
+These tests pin the two properties that buys: the held-out split costs nothing
+until something touches it, and threading the decode does not change a pixel.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from metal_gauss.blender import load_blender
+
+_GL2CV = np.diag([1.0, -1.0, -1.0, 1.0]).astype(np.float32)
+
+
+def _write_scene(root, n_train=3, n_test=5, size=16):
+    """A miniature NeRF-synthetic scene: RGBA PNGs plus the two transforms."""
+    from PIL import Image
+
+    rng = np.random.default_rng(0)
+    for split, n in (("train", n_train), ("test", n_test)):
+        (root / split).mkdir(parents=True, exist_ok=True)
+        frames = []
+        for i in range(n):
+            px = rng.integers(0, 256, (size, size, 4), dtype=np.uint8)
+            Image.fromarray(px, mode="RGBA").save(root / split / f"r_{i}.png")
+            c2w = np.eye(4, dtype=np.float32)
+            c2w[:3, 3] = [float(i), 1.0, 2.0]
+            frames.append({"file_path": f"./{split}/r_{i}",
+                           "transform_matrix": c2w.tolist()})
+        (root / f"transforms_{split}.json").write_text(
+            json.dumps({"camera_angle_x": 0.69, "frames": frames}))
+    return root
+
+
+@pytest.fixture
+def scene_root(tmp_path):
+    return _write_scene(tmp_path / "mini")
+
+
+def _count_opens(monkeypatch):
+    """Count PIL decodes, by name, without changing what they return."""
+    from PIL import Image
+
+    opened = []
+    real = Image.open
+
+    def spy(fp, *a, **kw):
+        # the split directory, not the whole path: pytest's own tmp dirs are
+        # named after the test, and "test_heldout_..." contains "test".
+        opened.append(f"{Path(fp).parent.name}/{Path(fp).name}")
+        return real(fp, *a, **kw)
+
+    monkeypatch.setattr(Image, "open", spy)
+    return opened
+
+
+def test_loading_a_scene_does_not_decode_the_heldout_split(scene_root, monkeypatch):
+    opened = _count_opens(monkeypatch)
+    load_blender(scene_root, max_resolution=16, n_init=8)
+    assert not [p for p in opened if p.startswith("test/")], \
+        "held-out PNGs were decoded during load"
+    assert len([p for p in opened if p.startswith("train/")]) == 3
+
+
+def test_heldout_length_is_known_without_decoding(scene_root, monkeypatch):
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    opened = _count_opens(monkeypatch)
+    assert len(scene.heldout) == 5
+    assert opened == [], "len() decoded the held-out split"
+
+
+def test_heldout_decodes_on_first_access(scene_root, monkeypatch):
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    opened = _count_opens(monkeypatch)
+    first = scene.heldout[0]
+    assert len([p for p in opened if p.startswith("test/")]) == 5
+    assert first.image.shape == (16, 16, 3)
+
+
+def test_heldout_decodes_only_once(scene_root, monkeypatch):
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    list(scene.heldout)
+    opened = _count_opens(monkeypatch)
+    list(scene.heldout)
+    assert opened == [], "held-out split decoded twice"
+
+
+def test_heldout_views_keep_their_identity(scene_root):
+    """`downscaled()` caches its pyramid on id(view); new objects would leak."""
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    assert scene.heldout[2] is scene.heldout[2]
+    assert list(scene.heldout)[2] is scene.heldout[2]
+
+
+def test_heldout_matches_a_straight_serial_decode(scene_root):
+    """The threaded, lazy path returns exactly the eager one's pixels."""
+    from PIL import Image
+
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    meta = json.loads((scene_root / "transforms_test.json").read_text())
+    angle_x = float(meta["camera_angle_x"])
+
+    for fr, got in zip(meta["frames"], scene.heldout):
+        p = scene_root / (fr["file_path"].lstrip("./") + ".png")
+        a = np.asarray(Image.open(p), dtype=np.float32) / 255.0
+        rgb = a[..., :3] * a[..., 3:4] + (1.0 - a[..., 3:4])
+        want = torch.from_numpy((rgb * 255).astype(np.uint8))
+        assert got.name == p.name
+        assert torch.equal(got.image, want)
+
+        W = H = 16
+        focal = 0.5 * W / math.tan(0.5 * angle_x)
+        K = torch.tensor([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1.0]])
+        assert torch.allclose(got.K, K)
+        c2w = np.array(fr["transform_matrix"], dtype=np.float32) @ _GL2CV
+        assert torch.allclose(got.viewmat,
+                              torch.from_numpy(np.linalg.inv(c2w).astype(np.float32)))
+
+
+def test_train_split_order_is_the_json_order(scene_root):
+    """rng.permutation(len(train)) indexes this list; order must be stable."""
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    assert [v.name for v in scene.train] == ["r_0.png", "r_1.png", "r_2.png"]
+
+
+def test_missing_frames_are_skipped_not_faked(scene_root):
+    (scene_root / "test" / "r_3.png").unlink()
+    scene = load_blender(scene_root, max_resolution=16, n_init=8)
+    assert len(scene.heldout) == 4
+    assert [v.name for v in scene.heldout] == \
+        ["r_0.png", "r_1.png", "r_2.png", "r_4.png"]


### PR DESCRIPTION
Closes #6, though not the way #6 proposed — see the [profiling comment](https://github.com/nandometzger/metal-gauss/issues/6#issuecomment-5544289901) there.

## What the 8.4 s actually was

Shader compilation, the target of the original issue, is **~30 ms**. Timing every phase from process start to the trainer's `t0` on lego at `max_resolution=800`:

| phase | before |
|---|---:|
| `load_blender` (300 images) | **6.12 s** |
| `import torch` + numpy | 0.77 s |
| `make_optimizer` | 0.69 s |
| `init_params` | 0.56 s |
| `_load` (extension + shaders, all in) | 0.55 s |
| **total to `t0`** | **8.70 s** |

## Two problems in the decode

**It decoded the held-out split eagerly.** 200 of those 300 images, 4.12 s, in a window that a run whose `eval_every` exceeds its step count never reads — including every fast-end row in `pareto_fastend.json`, which has `eval_every: 1000` at `steps: 100`. `bench/compare/blender_to_nerfstudio.py` emits train frames only and scores every implementation afterwards with the shared evaluator, so competing trainers were never charged for those 200 images and we were.

**It decoded serially.** PIL releases the GIL for both decode and resize; a thread pool measured 3.4x on ten cores.

## The change

`_frames()` separates what the transforms JSON knows — how many views a split has, and which files are actually present — from decoding pixels. `Scene.heldout` becomes a `LazyViews`: `len()` answers from the frame list without touching a PNG, and the images are decoded on first access and then kept, because `downscaled()` caches its pyramid on `id(view)` and handing out fresh objects per access would quietly defeat that cache.

The decode moves to a thread pool bounded at 8 workers. Results stay in JSON order rather than completion order: the trainer indexes the training list with a seeded permutation, so reordering here would change which views a "reproducible" run trains on without changing anything visible.

`Scene.train`/`heldout` are now typed `Sequence[View]`. The COLMAP path is untouched and still builds plain lists.

## Results

Startup on lego via `bench/startup_profile.py`:

~~~text
before   8.60 / 8.80 s warm
after    2.80 / 3.10 s warm
~~~

Wall clock at the fast end, back to back on the same machine:

| iters | before | after |
|---:|---:|---:|
| 100 | 13.3 s | **8.9 s** |
| 200 | 14.5 s | **9.9 s** |
| 300 | 17.6 s | **11.1 s** |
| 500 | 18.7 s | **13.3 s** |

## Correctness

A 200-step run at `--seed 0` gives the same loss (`0.1594`) and the same held-out PSNR (`15.34 dB`) on both loaders — so the lazy split is still read, and still read correctly, when a run does evaluate.

Eight new tests in `tests/test_blender_loading.py`, written first and watched fail against the old loader (2 failed for the right reason, 6 passed as regression guards). They build a miniature scene in `tmp_path`, so they need no dataset and run in the hosted Metal job. They pin: no held-out PNG is opened during load; `len()` decodes nothing; first access decodes exactly once; view identity is stable across accesses; pixels, intrinsics and view matrices match a straight serial decode; train order is JSON order; missing frames are skipped rather than faked.

Full suite: **196 passed**. `bench/readme_tables.py --check` clean, `git diff --check` clean.

## Published numbers

`bench/results/startup_{warm,cold}.json` are re-measured on this code. The README caveat that quoted a "~8.4 s of fixed startup" floor now quotes ~3 s and states plainly that the budget table above it was measured before this change and has not been re-run.

## The 8-scene front, re-measured

All 48 metal-gauss rows in `sweep8` were re-run on this change — sequentially, on an otherwise idle machine, 1.77 h. `pareto_8scene.svg` and `margin_forest.svg` are regenerated from them.

The budget table moves in one place:

| budget | before | after |
|---|---:|---:|
| 30 s | 21.51 | 21.55 |
| **1 min** | **24.16** | **24.69** |
| 3 min | 29.81 | 29.78 |
| 6 min | 31.42 | 31.34 |
| 15 / 30 min | 31.87 | 31.87 |

**+0.54 dB at 1 min, nothing else.** The 3 and 6 min moves are −0.04 and −0.08 dB, inside the 0.19 dB noise floor this repo publishes for itself.

The saving behaves as the profile predicted and no better:

| rung | median Δwall | range |
|---:|---:|---|
| 500 | **−4.4 s** | −6.4 … −2.6 (every scene negative) |
| 1 000 | −3.1 s | −5.6 … +2.5 |
| 2 000 | −1.4 s | −7.8 … +8.6 |
| 7 000 | −9.4 s | −45.0 … +32.2 |
| 15 000 | +0.9 s | −71.3 … +41.6 |

Past ~2 000 iterations the run-to-run spread is ±40 s and swamps a 4 s startup change — lego came out 41.6 s *slower* at 15 k and chair 24.1 s faster, on identical code. That is the boost-clock variance `CONTRIBUTING.md` warns about, and nothing here is claimed from it. PSNR moves ≤0.18 dB per rung in both directions, consistent with the atomics non-determinism `train.py` documents.

**Competitor rows are untouched and predate this change.** `/tmp/cmp_msplat`, `/tmp/cmp_brush` and `/tmp/cmp_spirula` are gone from this machine, so no competitor row could be regenerated without reinstalling all three first. The README caveat now states the mixed provenance rather than leaving a reader to assume one protocol. A follow-up branch makes those installs reproducible and pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgF2wYZQatvZN39eSJN5BY
